### PR TITLE
Re-order sidebar so pools are underneath Stability pools nav item

### DIFF
--- a/src/react/components/Navbar.tsx
+++ b/src/react/components/Navbar.tsx
@@ -77,6 +77,21 @@ export default function Navbar() {
           </ListItemButton>
         </ListItem>
 
+        {isSignedIn && (
+          <ListItem disablePadding>
+            <ListItemButton
+              component={Link}
+              to="/admin"
+              selected={location.pathname === '/admin'}
+            >
+              <ListItemIcon>
+                <AdminIcon />
+              </ListItemIcon>
+              {open && <ListItemText primary="Admin" />}
+            </ListItemButton>
+          </ListItem>
+        )}
+
         <ListItem disablePadding>
           <ListItemButton
             component={Link}
@@ -103,20 +118,18 @@ export default function Navbar() {
           </ListItemButton>
         </ListItem>
 
-        {isSignedIn && (
-        <ListItem disablePadding>
+        {open && Object.keys(contractMapping).map((symbol) => (
+          <ListItem key={symbol} disablePadding>
             <ListItemButton
               component={Link}
-              to="/admin"
-              selected={location.pathname === '/admin'}
+              to={`/cdps/${symbol}`}
+              selected={location.pathname === `/cdps/${symbol}`}
+              sx={{ pl: 4 }}
             >
-              <ListItemIcon>
-                <AdminIcon />
-              </ListItemIcon>
-              {open && <ListItemText primary="Admin" />}
+              <ListItemText primary={symbol} />
             </ListItemButton>
           </ListItem>
-        )}
+        ))}
 
         <ListItem disablePadding>
           <ListItemButton
@@ -142,19 +155,6 @@ export default function Navbar() {
             {open && <ListItemText primary={`${isDarkMode ? 'Light' : 'Dark'} Mode`} />}
           </ListItemButton>
         </ListItem>
-
-        {open && Object.keys(contractMapping).map((symbol) => (
-          <ListItem key={symbol} disablePadding>
-            <ListItemButton
-              component={Link}
-              to={`/cdps/${symbol}`}
-              selected={location.pathname === `/cdps/${symbol}`}
-              sx={{ pl: 4 }}
-            >
-              <ListItemText primary={symbol} />
-            </ListItemButton>
-          </ListItem>
-        ))}
       </List>
     </Drawer>
   );


### PR DESCRIPTION
Re-order the sidebar so the pools are with the pools

Before
<img width="231" alt="Screenshot 2025-04-16 at 4 51 34 PM" src="https://github.com/user-attachments/assets/39472fdb-8de3-4eac-b9fe-aedd4955f49f" />

After
<img width="237" alt="Screenshot 2025-04-16 at 4 50 55 PM" src="https://github.com/user-attachments/assets/83d097f9-995e-4ef7-ae06-92491fad6752" />
