### PR TITLE
Style: #12 Adjust Metric Cards

### DIFF
--- a/src/react/components/Dashboard.tsx
+++ b/src/react/components/Dashboard.tsx
@@ -106,7 +106,13 @@ export default function Dashboard() {
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: theme.palette.background.default }}>
       {/* Top Metrics Grid */}
-      <Grid container spacing={3} mb={4} className="metric-card-grid">
+      <Grid container spacing={3} mb={4} className="metric-card-grid" id="metric-cards"
+        sx={{
+          margin: 0,
+          width: 1,
+          gap: '20px'
+        }}
+      >
         {topMetrics.map((metric, index) => (
           <Grid item xs={12} md={3} key={index} className="metric-card-container">
             <MetricCard

--- a/src/react/components/Dashboard.tsx
+++ b/src/react/components/Dashboard.tsx
@@ -106,9 +106,9 @@ export default function Dashboard() {
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: theme.palette.background.default }}>
       {/* Top Metrics Grid */}
-      <Grid container spacing={3} mb={4}>
+      <Grid container spacing={3} mb={4} className="metric-card-grid">
         {topMetrics.map((metric, index) => (
-          <Grid item xs={12} md={3} key={index}>
+          <Grid item xs={12} md={3} key={index} className="metric-card-container">
             <MetricCard
               title={metric.title}
               value={metric.format(metric.value)}

--- a/src/react/components/common/MetricCard.tsx
+++ b/src/react/components/common/MetricCard.tsx
@@ -28,6 +28,7 @@ export const MetricCard = ({
 
   return (
     <Paper 
+      className='metric-card-paper-root'
       sx={{ 
         display: 'flex',
         flexDirection: 'column',
@@ -35,12 +36,11 @@ export const MetricCard = ({
         alignItems: 'center',
         p: 2, 
         height: '100%', 
-        bgcolor: 'rgba(0, 0, 0, 0.2)',
         borderRadius: '20px',
         transition: 'transform 0.2s',
         '&:hover': {
           transform: 'translateY(-2px)'
-        }
+        },
       }}
     >
 
@@ -78,7 +78,8 @@ export const MetricCard = ({
             variant="caption"
             sx={{
               color: isPositiveChange ? 'success.main' : 'error.main',
-              fontWeight: 500
+              fontWeight: 500,
+              fontSize: 18
             }}
           >
             {formattedChange}%
@@ -95,7 +96,8 @@ export const MetricCard = ({
             sx={{ 
               mt: '10px',
               mb: 1,
-              fontWeight: 500
+              fontWeight: 800,
+              fontSize: 38
             }}
           >
             {value}

--- a/src/react/components/common/MetricCard.tsx
+++ b/src/react/components/common/MetricCard.tsx
@@ -78,8 +78,8 @@ export const MetricCard = ({
             variant="caption"
             sx={{
               color: 'black',
-              fontWeight: 500,
-              fontSize: 18
+              fontWeight: 600,
+              fontSize: 16
             }}
           >
             {formattedChange}%
@@ -97,7 +97,7 @@ export const MetricCard = ({
               mt: '10px',
               mb: 1,
               fontWeight: 800,
-              fontSize: 38
+              fontSize: 34
             }}
           >
             {value}

--- a/src/react/components/common/MetricCard.tsx
+++ b/src/react/components/common/MetricCard.tsx
@@ -29,15 +29,91 @@ export const MetricCard = ({
   return (
     <Paper 
       sx={{ 
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
         p: 2, 
         height: '100%', 
         bgcolor: 'rgba(0, 0, 0, 0.2)',
+        borderRadius: '20px',
         transition: 'transform 0.2s',
         '&:hover': {
           transform: 'translateY(-2px)'
         }
       }}
     >
+
+      {change !== undefined && !isLoading && (
+        <Box 
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            bgcolor: isPositiveChange 
+              ? 'rgba(45, 192, 113, 0.15)' 
+              : 'rgba(255, 72, 66, 0.15)',
+            px: 1,
+            py: 0.5,
+            borderRadius: '15px'
+          }}
+        >
+          {isPositiveChange ? (
+            <TrendingUp 
+              sx={{ 
+                fontSize: 16, 
+                color: 'success.main',
+                mr: 0.5 
+              }} 
+            />
+          ) : (
+            <TrendingDown 
+              sx={{ 
+                fontSize: 16, 
+                color: 'error.main',
+                mr: 0.5 
+              }} 
+            />
+          )}
+          <Typography
+            variant="caption"
+            sx={{
+              color: isPositiveChange ? 'success.main' : 'error.main',
+              fontWeight: 500
+            }}
+          >
+            {formattedChange}%
+          </Typography>
+        </Box>
+      )}
+      {isLoading ? (
+        <Skeleton variant="text" width="80%" height={60} />
+      ) : (
+        <>
+          <Typography 
+            variant="h4" 
+            component="p" 
+            sx={{ 
+              mt: '10px',
+              mb: 1,
+              fontWeight: 500
+            }}
+          >
+            {value}
+            {trend && (
+              <Typography
+                component="span"
+                sx={{
+                  ml: 1,
+                  color: trend.isPositive ? 'success.main' : 'error.main',
+                  fontSize: '1rem'
+                }}
+              >
+                {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%
+              </Typography>
+            )}
+          </Typography>
+        </>
+      )}
       <Box display="flex" justifyContent="space-between" alignItems="flex-start">
         <Box display="flex" alignItems="center" mb={1}>
           <Typography 
@@ -61,79 +137,9 @@ export const MetricCard = ({
           )}
         </Box>
 
-        {change !== undefined && !isLoading && (
-          <Box 
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              bgcolor: isPositiveChange 
-                ? 'rgba(45, 192, 113, 0.15)' 
-                : 'rgba(255, 72, 66, 0.15)',
-              px: 1,
-              py: 0.5,
-              borderRadius: 1,
-            }}
-          >
-            {isPositiveChange ? (
-              <TrendingUp 
-                sx={{ 
-                  fontSize: 16, 
-                  color: 'success.main',
-                  mr: 0.5 
-                }} 
-              />
-            ) : (
-              <TrendingDown 
-                sx={{ 
-                  fontSize: 16, 
-                  color: 'error.main',
-                  mr: 0.5 
-                }} 
-              />
-            )}
-            <Typography
-              variant="caption"
-              sx={{
-                color: isPositiveChange ? 'success.main' : 'error.main',
-                fontWeight: 500
-              }}
-            >
-              {formattedChange}%
-            </Typography>
-          </Box>
-        )}
+ 
       </Box>
-      
-      {isLoading ? (
-        <Skeleton variant="text" width="80%" height={60} />
-      ) : (
-        <>
-          <Typography 
-            variant="h4" 
-            component="p" 
-            sx={{ 
-              mb: 1,
-              fontWeight: 500
-            }}
-          >
-            {value}
-            {trend && (
-              <Typography
-                component="span"
-                sx={{
-                  ml: 1,
-                  color: trend.isPositive ? 'success.main' : 'error.main',
-                  fontSize: '1rem'
-                }}
-              >
-                {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%
-              </Typography>
-            )}
-          </Typography>
-        </>
-      )}
-      
-      {subtitle && (
+      {false && subtitle && (
         <Typography 
           variant="body2" 
         >

--- a/src/react/components/common/MetricCard.tsx
+++ b/src/react/components/common/MetricCard.tsx
@@ -49,19 +49,19 @@ export const MetricCard = ({
           sx={{
             display: 'flex',
             alignItems: 'center',
-            bgcolor: isPositiveChange 
-              ? 'rgba(45, 192, 113, 0.15)' 
-              : 'rgba(255, 72, 66, 0.15)',
-            px: 1,
-            py: 0.5,
-            borderRadius: '15px'
+            bgcolor: isPositiveChange
+              ? '#648153'
+              : '#D46565',
+            px: 2,
+            py: 1.25,
+            borderRadius: '25px'
           }}
         >
           {isPositiveChange ? (
             <TrendingUp 
               sx={{ 
                 fontSize: 16, 
-                color: 'success.main',
+                color: 'white',
                 mr: 0.5 
               }} 
             />
@@ -69,7 +69,7 @@ export const MetricCard = ({
             <TrendingDown 
               sx={{ 
                 fontSize: 16, 
-                color: 'error.main',
+                color: 'white',
                 mr: 0.5 
               }} 
             />
@@ -77,7 +77,7 @@ export const MetricCard = ({
           <Typography
             variant="caption"
             sx={{
-              color: isPositiveChange ? 'success.main' : 'error.main',
+              color: 'black',
               fontWeight: 500,
               fontSize: 18
             }}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -234,6 +234,10 @@ code {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
+[data-theme="dark"] .metric-card-container {
+  background-color: #1A1C21;
+}
+
 [data-theme="dark"] .MuiButtonBase-root.Mui-selected {
   .MuiListItemIcon-root {
     .MuiSvgIcon-root {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -230,17 +230,45 @@ code {
   }
 }
 
+@media (min-width: 900px) {
+  #metric-cards {
+    flex-wrap: nowrap;
+  }
+}
+
+#metric-cards > .MuiGrid-item { 
+  padding: 0;
+}
+
+[data-theme="dark"] #metric-cards > .MuiGrid-item { 
+  border-color: white;
+}
+
 * {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .metric-card-grid {
   padding: 20px;
+  background-color: var(--color-surface-light);
+  border-radius: 20px;
+}
+
+[data-theme="dark"] .metric-card-grid {
   background-color: #1A1C21;
+}
+
+.metric-card-paper-root {
+  border: 1px black solid;
 }
 
 [data-theme="dark"] .metric-card-paper-root {
   background-color: #000;
+  border-color: white;
+}
+
+.metric-card-container {
+  border-radius: 20px;
 }
 
 [data-theme="dark"] .metric-card-container {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -234,6 +234,15 @@ code {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
+.metric-card-grid {
+  padding: 20px;
+  background-color: #1A1C21;
+}
+
+[data-theme="dark"] .metric-card-paper-root {
+  background-color: #000;
+}
+
 [data-theme="dark"] .metric-card-container {
   background-color: #1A1C21;
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -107,7 +107,7 @@ const getTheme = (mode: 'light' | 'dark') => createTheme({
             mode === 'dark'
               ? '0 1px 3px rgb(0, 0, 0)'
               : '0 1px 3px rgb(0, 0, 0, 0.10)',
-          '&.MuiPaper-root': {
+          '&.MuiPaper-elevation0': {
             backgroundColor: mode === 'dark' ? darkGray : white,
           },
         },


### PR DESCRIPTION
### Styles Adjusted
Cards were bordered, and rounded. Trend delta move to the top of the card with quantity and subtitle following. Coloring changed to be more align with design document. Changes should work for both dark and light mode.

Rendering on my machine:
<img width="1189" alt="Screenshot 2025-04-21 at 17 10 21" src="https://github.com/user-attachments/assets/453dfa04-3591-4862-b364-ae9696b4c26d" />

NOTE:
The coloring for a negative delta was "guessed at", hopefully reasonable.

Relevant Taiga Card:
https://taiga.pesto.rocks/project/equitx/us/12?milestone=28