### PR TITLE
fix: auth error on repay debt

### DIFF
--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -584,7 +584,6 @@ impl IsCollateralized for Token {
     }
 
     fn repay_debt(&mut self, lender: Address, amount: i128) -> Result<(), Error> {
-        lender.require_auth();
         let mut cdp = self.cdp(lender.clone())?;
     
         if matches!(cdp.status, CDPStatus::Closed) || matches!(cdp.status, CDPStatus::Frozen) {


### PR DESCRIPTION
Fixes double auth error in repay_debt. No need to call require_auth in repay debt anymore since its already being called in pay interest.