### PR TITLE
Create asset in database after deploying to mercury, to add wasm_hash

### DIFF
--- a/server/src/controllers/adminController.ts
+++ b/server/src/controllers/adminController.ts
@@ -92,6 +92,7 @@ export const deployAsset: RequestHandler = async (req, res) => {
     const contractIds = existingLiquidityPools.map((lp) => lp.pool_address);
     contractIds.push(contractId);
     console.log("DB contract IDs")
+    console.log(contractIds)
     console.log("Includes contract ID: ", contractIds.includes(contractId))
     // Deploy to Mercury with Mercury-enabled build
     const mercuryArgs = [


### PR DESCRIPTION
After the wasm_hash fix, admin deploys should create the new asset (and liquidity pool) in the database _after_ mercury has updated.