### PR TITLE
fix: repay debt error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,12 @@ jobs:
       uses: cargo-bins/cargo-binstall@v1.12.3
     - name: Install loam
       run: cargo binstall loam-cli
+    - name: Install cargo-nextest
+      run: cargo binstall cargo-nextest
     - name: Build & build clients with Loam
       run: LOAM_ENV=testing loam build --build-clients
     - name: Cargo build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo nextest run --verbose --no-fail-fast
+

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ src/contracts/*
 
 # contracts copied to server for server deployment
 server/prebuilt_contracts
+
+# Test snapshots
+contracts/test_snapshots/
+**/test_snapshots/

--- a/contracts/xasset-orchestrator/src/orchestrator.rs
+++ b/contracts/xasset-orchestrator/src/orchestrator.rs
@@ -47,7 +47,10 @@ pub trait IsOrchestratorTrait {
         decimals: u32,
         annual_interest_rate: u32,
     ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
-    fn get_asset_contract(&self, asset_symbol: loam_sdk::soroban_sdk::String) -> Result<loam_sdk::soroban_sdk::Address, Error>;
+    fn get_asset_contract(
+        &self,
+        asset_symbol: loam_sdk::soroban_sdk::String,
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
     // Manually set an asset symbol to an existing contract address
     fn set_asset_contract(
         &mut self,

--- a/contracts/xasset/src/collateralized.rs
+++ b/contracts/xasset/src/collateralized.rs
@@ -3,7 +3,10 @@ use loam_sdk::{
     subcontract,
 };
 
-use crate::{storage::Interest, Error, PriceData};
+use crate::{
+    storage::{Interest, InterestDetail},
+    Error, PriceData,
+};
 
 #[loam_sdk::soroban_sdk::contracttype]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -110,7 +113,7 @@ pub trait IsCollateralized {
     fn close_cdp(&mut self, lender: Address) -> Result<(), Error>;
 
     /// Updates and returns the accrued interest on a cdp
-    fn get_accrued_interest(&self, lender: Address) -> Result<Interest, Error>;
+    fn get_accrued_interest(&self, lender: Address) -> Result<InterestDetail, Error>;
 
     /// Pay the interest on a CDP
     fn pay_interest(&mut self, lender: Address, amount: i128) -> Result<CDPContract, Error>;

--- a/contracts/xasset/src/collateralized.rs
+++ b/contracts/xasset/src/collateralized.rs
@@ -6,7 +6,7 @@ use loam_sdk::{
 use crate::{storage::Interest, Error, PriceData};
 
 #[loam_sdk::soroban_sdk::contracttype]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 /// Descriptions of these on page 5 of Indigo white paper
 pub enum CDPStatus {
     /// A CDP that is fully collateralized, with its CR value above the xAsset’s MCR. Open CDPs remain fully usable by their lenders.

--- a/contracts/xasset/src/error.rs
+++ b/contracts/xasset/src/error.rs
@@ -87,4 +87,7 @@ pub enum Error {
 
     // Invoking XLM SAC contract failed
     XLMHostInvocationFailed = 28,
+
+    // Interest repaid must be greater than 0
+    InterestRepaidNotPositive = 29,
 }

--- a/contracts/xasset/src/error.rs
+++ b/contracts/xasset/src/error.rs
@@ -4,90 +4,90 @@ use loam_sdk::soroban_sdk::{self, contracterror};
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    // "Insufficient collateralization ratio"
+    /// "Insufficient collateralization ratio"
     InsufficientCollateralization = 1,
 
-    // "CDP already exists for this lender"
+    /// "CDP already exists for this lender"
     CDPAlreadyExists = 2,
 
-    // "CDP not found"
+    /// "CDP not found"
     CDPNotFound = 3,
 
-    // "CDP not insolvent"
+    /// "CDP not insolvent"
     CDPNotInsolvent = 4,
 
-    // "CDP must be Open to borrow asset"
+    /// "CDP must be Open to borrow asset"
     CDPNotOpen = 5,
 
-    // "Insufficient collateral"
+    /// "Insufficient collateral"
     InsufficientCollateral = 6,
 
-    // "Insufficient balance"
+    /// "Insufficient balance"
     InsufficientBalance = 7,
 
-    // "Repayment amount exceeds debt"
+    /// "Repayment amount exceeds debt"
     RepaymentExceedsDebt = 8,
 
-    // "Cannot close CDP with outstanding debt"
+    /// "Cannot close CDP with outstanding debt"
     OutstandingDebt = 9,
 
-    // "At least two CDPs are required for merging" or "All CDPs must be frozen to merge"
+    /// "At least two CDPs are required for merging" or "All CDPs must be frozen to merge"
     InvalidMerge = 10,
 
-    // "CDP must be frozen to be liquidated" or "Debt and collateral must be positive"
+    /// "CDP must be frozen to be liquidated" or "Debt and collateral must be positive"
     InvalidLiquidation = 11,
 
-    // "Withdrawal would cause undercollateralization"
+    /// "Withdrawal would cause undercollateralization"
     InvalidWithdrawal = 12,
 
-    // "CDP must be Open or Insolvent to add collateral"
+    /// "CDP must be Open or Insolvent to add collateral"
     CDPNotOpenOrInsolvent = 13,
 
-    // "CDP must be Open or Insolvent to repay debt"
+    /// "CDP must be Open or Insolvent to repay debt"
     CDPNotOpenOrInsolventForRepay = 14,
 
-    // "User already has a stake. Use deposit function to add to existing stake."
+    /// "User already has a stake. Use deposit function to add to existing stake."
     StakeAlreadyExists = 15,
 
-    // "User does not have a stake. Use stake function to create one."
+    /// "User does not have a stake. Use stake function to create one."
     StakeDoesntExist = 16,
 
-    // "live_until_ledger must be greater than or equal to the current ledger number"
+    /// "live_until_ledger must be greater than or equal to the current ledger number"
     InvalidLedgerSequence = 17,
 
-    // "Failed to fetch price data from the Oracle"
+    /// "Failed to fetch price data from the Oracle"
     OraclePriceFetchFailed = 18,
 
-    // "Failed to fetch decimals from the Oracle"
+    /// "Failed to fetch decimals from the Oracle"
     OracleDecimalsFetchFailed = 19,
 
-    // "Failed to transfer XLM"
+    /// "Failed to transfer XLM"
     XLMTransferFailed = 20,
 
-    // "Claim rewards from previous epoch before modifying position"
+    /// "Claim rewards from previous epoch before modifying position"
     ClaimRewardsFirst = 21,
 
-    // "Insufficient amount of xAsset staked
+    /// "Insufficient amount of xAsset staked
     InsufficientStake = 22,
 
-    // "Insufficient interest"
+    /// "Insufficient interest"
     InsufficientInterest = 23,
 
-    // Payment exceeds interest due
+    /// Payment exceeds interest due
     PaymentExceedsInterestDue = 24,
 
-    // "Interest must be paid before debt can be repaid"
+    /// "Interest must be paid before debt can be repaid"
     InterestMustBePaidFirst = 25,
 
-    // "Insufficient XLM to pay interest"
+    /// "Insufficient XLM to pay interest"
     InsufficientXLMForInterest = 26,
 
-    // Approval needed for interest repayment
+    /// Approval needed for interest repayment
     InsufficientApprovedXLMForInterestRepayment = 27,
 
-    // Invoking XLM SAC contract failed
+    /// Invoking XLM SAC contract failed
     XLMInvocationFailed = 28,
 
-    // Interest repaid must be greater than 0
+    /// Interest repaid must be greater than 0
     InterestRepaidNotPositive = 29,
 }

--- a/contracts/xasset/src/error.rs
+++ b/contracts/xasset/src/error.rs
@@ -75,7 +75,7 @@ pub enum Error {
 
     // Payment exceeds interest due
     PaymentExceedsInterestDue = 24,
-    
+
     // "Interest must be paid before debt can be repaid"
     InterestMustBePaidFirst = 25,
 

--- a/contracts/xasset/src/error.rs
+++ b/contracts/xasset/src/error.rs
@@ -81,4 +81,10 @@ pub enum Error {
 
     // "Insufficient XLM to pay interest"
     InsufficientXLMForInterest = 26,
+
+    // Approval needed for interest repayment
+    InsufficientApprovedXLMForInterestRepayment = 27,
+
+    // Invoking XLM SAC contract failed
+    XLMHostInvocationFailed = 28,
 }

--- a/contracts/xasset/src/error.rs
+++ b/contracts/xasset/src/error.rs
@@ -86,7 +86,7 @@ pub enum Error {
     InsufficientApprovedXLMForInterestRepayment = 27,
 
     // Invoking XLM SAC contract failed
-    XLMHostInvocationFailed = 28,
+    XLMInvocationFailed = 28,
 
     // Interest repaid must be greater than 0
     InterestRepaidNotPositive = 29,

--- a/contracts/xasset/src/index_types.rs
+++ b/contracts/xasset/src/index_types.rs
@@ -1,6 +1,6 @@
-use retroshade_sdk::Retroshade;
-use loam_sdk::soroban_sdk::{self, contracttype, Address };
 use crate::collateralized::CDPStatus;
+use loam_sdk::soroban_sdk::{self, contracttype, Address};
+use retroshade_sdk::Retroshade;
 
 #[derive(Retroshade)]
 #[contracttype]
@@ -12,7 +12,7 @@ pub struct CDP {
     pub ledger: u32,
     pub timestamp: u64,
     pub accrued_interest: i128,
-    pub interest_paid: i128, 
+    pub interest_paid: i128,
     pub last_interest_time: u64,
 }
 

--- a/contracts/xasset/src/lib.rs
+++ b/contracts/xasset/src/lib.rs
@@ -54,4 +54,4 @@ impl Contract {
     }
 }
 
-//mod test;
+mod test;

--- a/contracts/xasset/src/lib.rs
+++ b/contracts/xasset/src/lib.rs
@@ -18,7 +18,7 @@ pub mod token;
 #[cfg(feature = "mercury")]
 pub mod index_types;
 
-use crate::storage::Interest;
+use crate::storage::InterestDetail;
 pub use error::Error;
 
 // FIXME: copied from data_feed; find way to reuse

--- a/contracts/xasset/src/lib.rs
+++ b/contracts/xasset/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use collateralized::{CDPAdmin, Collateralized, CDPContract, CDPStatus};
+use collateralized::{CDPAdmin, CDPContract, CDPStatus, Collateralized};
 use loam_sdk::{
     derive_contract,
     soroban_sdk::{self, Address, String, Symbol, Vec},
@@ -11,15 +11,15 @@ use token::Token;
 
 pub mod collateralized;
 pub mod error;
-mod storage;
 pub mod stability_pool;
+mod storage;
 pub mod token;
 
 #[cfg(feature = "mercury")]
 pub mod index_types;
 
-pub use error::Error;
 use crate::storage::Interest;
+pub use error::Error;
 
 // FIXME: copied from data_feed; find way to reuse
 #[loam_sdk::soroban_sdk::contracttype]

--- a/contracts/xasset/src/stability_pool.rs
+++ b/contracts/xasset/src/stability_pool.rs
@@ -6,7 +6,6 @@ use loam_sdk::{
 use crate::{collateralized::CDPStatus, Error};
 const PRODUCT_CONSTANT: i128 = 1_000_000_000;
 
-
 #[contracttype]
 #[derive(Clone)]
 pub struct StakerPosition {

--- a/contracts/xasset/src/storage.rs
+++ b/contracts/xasset/src/storage.rs
@@ -54,3 +54,18 @@ pub struct Interest {
     /// Amount of interest paid
     pub paid: i128,
 }
+
+#[contracttype]
+#[derive(Clone, Copy, Default)]
+pub struct InterestDetail {
+    /// Amount of interest accrued
+    pub amount: i128,
+    /// Amount of interest paid
+    pub paid: i128,
+    /// Amount of interest accrued in XLM
+    pub amountInXLM: i128,
+    /// Amount of interest in XLM that will accrue 5 minutes from now
+    pub approvalAmount: i128,
+    /// Unix timestamp of when interest accrual was last calculated
+    pub lastInterestTime: u64,
+}

--- a/contracts/xasset/src/storage.rs
+++ b/contracts/xasset/src/storage.rs
@@ -63,9 +63,9 @@ pub struct InterestDetail {
     /// Amount of interest paid
     pub paid: i128,
     /// Amount of interest accrued in XLM
-    pub amountInXLM: i128,
+    pub amount_in_xlm: i128,
     /// Amount of interest in XLM that will accrue 5 minutes from now
-    pub approvalAmount: i128,
+    pub approval_amount: i128,
     /// Unix timestamp of when interest accrual was last calculated
-    pub lastInterestTime: u64,
+    pub last_interest_time: u64,
 }

--- a/contracts/xasset/src/storage.rs
+++ b/contracts/xasset/src/storage.rs
@@ -41,7 +41,7 @@ impl CDPInternal {
             asset_lent,
             status: CDPStatus::Open,
             accrued_interest: Interest::default(),
-            last_interest_time: timestamp, 
+            last_interest_time: timestamp,
         }
     }
 }

--- a/contracts/xasset/src/test.rs
+++ b/contracts/xasset/src/test.rs
@@ -6,12 +6,41 @@ use crate::data_feed::Client as DataFeedClient;
 // use crate::data_feed::DataFeed;
 
 use crate::data_feed::Asset;
-use loam_sdk::soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
+use loam_sdk::soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env, String, Symbol};
+
+// TODO: Rust isn't resolving these macros
+// to make a mock for the xlm_contract and asset_contract
+
+// #[contract]
+// pub struct MockPriceFeed {
+//     last_price: i128,
+// }
+
+// #[contractimpl]
+// impl MockPriceFeed {
+//     pub fn new(last_price: i128) -> Self {
+//         Self { last_price }
+//     }
+// }
+
+// impl MockPriceFeed {
+//     pub fn get_last_price(&self) -> i128 {
+//         self.last_price
+//     }
+// }
+
+// fn create_mock_price_feed(e: &Env, last_price: i128) -> Address {
+//     let mock_contract = MockPriceFeed::new(last_price);
+//     let contract_id = e.register(MockPriceFeed, last_price);
+//     Address::from(contract_id)
+// }
 
 fn create_token_contract<'a>(e: &Env) -> SorobanContract__Client<'a> {
     let token = SorobanContract__Client::new(e, &e.register_contract(None, SorobanContract__ {}));
     let xlm_sac = Address::generate(e);
+    // TODO: this needs to be a mock contract
     let xlm_contract = Address::generate(e);
+    // TODO: this needs to be a mock contract
     let asset_contract = Address::generate(e);
     let pegged_asset = Symbol::new(e, "USDT");
     let min_collat_ratio = 11000;

--- a/contracts/xasset/src/test.rs
+++ b/contracts/xasset/src/test.rs
@@ -403,16 +403,14 @@ fn test_cdp_operations_with_interest() {
 
     // Use contract-provided view to get approval info
     let interest_detail = token.get_accrued_interest(&alice);
-    let approval_amount = interest_detail.approvalAmount; // amount of xlm needed for the next 5 minutes
+    let approval_amount = interest_detail.approval_amount; // amount of xlm needed for the next 5 minutes
 
     // Approve contract to spend XLM from Alice for paying interest
-    let contract_address = token.address.clone();
-    let live_until_ledger = e.ledger().sequence() + 100;
     sac_contract.approve(
         &alice,
-        &contract_address,
+        &token.address.clone(),
         &approval_amount,
-        &live_until_ledger,
+        &(e.ledger().sequence() + 100),
     );
 
     // Repay some debt (this should first pay off accrued interest)

--- a/contracts/xasset/src/test.rs
+++ b/contracts/xasset/src/test.rs
@@ -2,23 +2,11 @@
 extern crate std;
 use crate::{collateralized::CDPStatus, data_feed::Asset, Error, PriceData, SorobanContract__, SorobanContract__Client, Token, CDP};
 
-use crate::data_feed::DataFeed;
+// use crate::data_feed::DataFeed;
+
 use loam_sdk::soroban_sdk::{
     testutils::Address as _, token, Address, Env, String, Symbol
 };
-
-fn create_datafeed_contract<'a>(
-    e: &Env,
-) -> data_feed::SorobanContract__Client<'a> {
-    let datafeed = data_feed::SorobanContract__Client::new(e, &e.register_contract(None, SorobanContract__ {}));
-    let asset_xlm: Asset = Asset::Other(Symbol::new(e, "XLM"));
-    let asset_xusd: Asset = Asset::Other(Symbol::new(e, "XUSD"));
-    let asset_vec = Vec::from_array(e, [asset_xlm.clone(), asset_xusd.clone()]);
-    let admin = Address::generate(&e);
-    datafeed.admin_set(&admin);
-    datafeed.sep40_init(&asset_vec, &asset_xusd, &14, &300);
-    datafeed
-}
 
 fn create_token_contract<'a>(e: &Env) -> SorobanContract__Client<'a> {
     let token = SorobanContract__Client::new(e, &e.register_contract(None, SorobanContract__ {}));
@@ -30,6 +18,7 @@ fn create_token_contract<'a>(e: &Env) -> SorobanContract__Client<'a> {
     let name = String::from_str(e, "United States Dollar xAsset");
     let symbol = String::from_str(e, "xUSD");
     let decimals = 7;
+    let annual_interest_rate: u32 = 11_00; // 11% interest rate
 
     token.cdp_init(
         &xlm_sac,
@@ -40,6 +29,7 @@ fn create_token_contract<'a>(e: &Env) -> SorobanContract__Client<'a> {
         &name,
         &symbol,
         &decimals,
+        &annual_interest_rate
     );
 
     token
@@ -66,23 +56,23 @@ fn test_cdp_operations() {
     let alice = Address::generate(&e);
     let bob = Address::generate(&e);
 
-    // Mock XLM price
-    token.set_xlm_contract(&e.register_contract(None, DataFeed::default()));
-    let xlm_price = 10_000_000_000_000;
-    token.set_asset_price(&Asset::Other(Symbol::new(&e, "XLM")), &xlm_price, &1000);
+    // // Mock XLM price
+    // token.set_xlm_contract(&e.register_contract(None, DataFeed::default()));
+    // let xlm_price = 10_000_000_000_000;
+    // token.set_asset_price(&Asset::Other(Symbol::new(&e, "XLM")), &xlm_price, &1000);
 
-    // Mock USDT price
-    token.set_asset_contract(&e.register_contract(None, DataFeed::default()));
-    let usdt_price = 100_000_000_000_000;
-    token.set_asset_price(&Asset::Other(Symbol::new(&e, "USDT")), &usdt_price, &1000);
+    // // Mock USDT price
+    // token.set_asset_contract(&e.register_contract(None, DataFeed::default()));
+    // let usdt_price = 100_000_000_000_000;
+    // token.set_asset_price(&Asset::Other(Symbol::new(&e, "USDT")), &usdt_price, &1000);
 
     // Open CDPs
-    token.open_cdp(&alice, &1_700_000_000, &100_000_000).unwrap();
-    token.open_cdp(&bob, &1_300_000_000, &100_000_000).unwrap();
+    token.open_cdp(&alice, &1_700_000_000, &100_000_000);
+    token.open_cdp(&bob, &1_300_000_000, &100_000_000);
 
     // Check CDPs
-    let alice_cdp = token.cdp(alice.clone()).unwrap();
-    let bob_cdp = token.cdp(bob.clone()).unwrap();
+    let alice_cdp = token.cdp(&alice.clone());
+    let bob_cdp = token.cdp(&bob.clone());
 
     assert_eq!(alice_cdp.xlm_deposited, 1_700_000_000);
     assert_eq!(alice_cdp.asset_lent, 100_000_000);
@@ -94,8 +84,8 @@ fn test_cdp_operations() {
     assert_eq!(token.minimum_collateralization_ratio(), 15000);
 
     // Check if CDPs become insolvent
-    let alice_cdp = token.cdp(alice.clone()).unwrap();
-    let bob_cdp = token.cdp(bob.clone()).unwrap();
+    let alice_cdp = token.cdp(&alice.clone());
+    let bob_cdp = token.cdp(&bob.clone());
 
     assert_eq!(alice_cdp.status, CDPStatus::Open);
     assert_eq!(bob_cdp.status, CDPStatus::Insolvent);
@@ -106,21 +96,21 @@ fn test_token_transfers() {
     let e = Env::default();
     e.mock_all_auths();
 
-    let mut token = create_token_contract(&e);
+    let token = create_token_contract(&e);
     let alice = Address::generate(&e);
     let bob = Address::generate(&e);
 
     // Mint tokens to Alice
     token.mint(&alice, &1000_0000000);
 
-    assert_eq!(token.balance(alice.clone()), 1000_0000000);
-    assert_eq!(token.balance(bob.clone()), 0);
+    assert_eq!(token.balance(&alice.clone()), 1000_0000000);
+    assert_eq!(token.balance(&bob.clone()), 0);
 
     // Transfer from Alice to Bob
     token.transfer(&alice, &bob, &500_0000000);
 
-    assert_eq!(token.balance(alice.clone()), 500_0000000);
-    assert_eq!(token.balance(bob.clone()), 500_0000000);
+    assert_eq!(token.balance(&alice.clone()), 500_0000000);
+    assert_eq!(token.balance(&bob.clone()), 500_0000000);
 }
 
 #[test]
@@ -135,13 +125,13 @@ fn test_allowances() {
     // Set allowance
     token.approve(&alice, &bob, &1000_0000000, &(e.ledger().sequence() + 1000));
 
-    assert_eq!(token.allowance(alice.clone(), bob.clone()), 1000_0000000);
+    assert_eq!(token.allowance(&alice.clone(), &bob.clone()), 1000_0000000);
 
     // Transfer from Alice to Bob using allowance
     token.transfer_from(&bob, &alice, &bob, &500_0000000);
 
-    assert_eq!(token.allowance(alice.clone(), bob.clone()), 500_0000000);
-    assert_eq!(token.balance(bob.clone()), 500_0000000);
+    assert_eq!(token.allowance(&alice.clone(), &bob.clone()), 500_0000000);
+    assert_eq!(token.balance(&bob.clone()), 500_0000000);
 }
 
 #[test]
@@ -158,12 +148,12 @@ fn test_stability_pool() {
     token.mint(&bob, &1000_0000000);
 
     // Stake in stability pool
-    token.stake(&alice, &500_0000000).unwrap();
-    token.stake(&bob, &700_0000000).unwrap();
+    token.stake(&alice, &500_0000000);
+    token.stake(&bob, &700_0000000);
 
     // Check stakes
-    let alice_stake = token.get_staker_deposit_amount(alice.clone()).unwrap();
-    let bob_stake = token.get_staker_deposit_amount(bob.clone()).unwrap();
+    let alice_stake = token.get_staker_deposit_amount(&alice.clone());
+    let bob_stake = token.get_staker_deposit_amount(&bob.clone());
 
     assert_eq!(alice_stake, 500_0000000);
     assert_eq!(bob_stake, 700_0000000);
@@ -172,9 +162,9 @@ fn test_stability_pool() {
     assert_eq!(token.get_total_xasset(), 1200_0000000);
 
     // Withdraw from stability pool
-    token.withdraw(&alice, &200_0000000).unwrap();
+    token.withdraw(&alice, &200_0000000);
 
-    let alice_stake = token.get_staker_deposit_amount(alice.clone()).unwrap();
+    let alice_stake = token.get_staker_deposit_amount(&alice.clone());
     assert_eq!(alice_stake, 300_0000000);
 }
 
@@ -187,30 +177,30 @@ fn test_liquidation() {
     let alice = Address::generate(&e);
 
     // Open CDP for Alice
-    token.open_cdp(&alice, &1000_0000000, &500_0000000).unwrap();
+    token.open_cdp(&alice, &1000_0000000, &500_0000000);
 
     // Set XLM price to make the CDP insolvent
-    token.set_xlm_contract(&e.register_contract(None, DataFeed::default()));
-    let xlm_price = 5_000_000_000_000; // Half the original price
-    token.set_asset_price(&Asset::Other(Symbol::new(&e, "XLM")), &xlm_price, &2000);
+    // token.set_xlm_contract(&e.register_contract(None, DataFeed::default()));
+    // let xlm_price = 5_000_000_000_000; // Half the original price
+    // // token.set_asset_price(&Asset::Other(Symbol::new(&e, "XLM")), &xlm_price, &2000);
 
-    // Check if the CDP is insolvent
-    let alice_cdp = token.cdp(alice.clone()).unwrap();
-    assert_eq!(alice_cdp.status, CDPStatus::Insolvent);
+    // // Check if the CDP is insolvent
+    // let alice_cdp = token.cdp(&alice.clone());
+    // assert_eq!(alice_cdp.status, CDPStatus::Insolvent);
 
-    // Freeze the CDP
-    token.freeze_cdp(alice.clone()).unwrap();
+    // // Freeze the CDP
+    // token.freeze_cdp(&alice.clone());
 
-    // Liquidate the CDP
-    let (liquidated_debt, liquidated_collateral) = token.liquidate_cdp(alice.clone()).unwrap();
+    // // Liquidate the CDP
+    // let (liquidated_debt, liquidated_collateral, status) = token.liquidate_cdp(&alice.clone());
 
-    assert!(liquidated_debt > 0);
-    assert!(liquidated_collateral > 0);
+    // assert!(liquidated_debt > 0);
+    // assert!(liquidated_collateral > 0);
 
-    // Check if the CDP is closed or has reduced debt/collateral
-    let alice_cdp = token.cdp(alice.clone()).unwrap();
-    assert!(alice_cdp.xlm_deposited < 1000_0000000);
-    assert!(alice_cdp.asset_lent < 500_0000000);
+    // // Check if the CDP is closed or has reduced debt/collateral
+    // let alice_cdp = token.cdp(@alice.clone());
+    // assert!(alice_cdp.xlm_deposited < 1000_0000000);
+    // assert!(alice_cdp.asset_lent < 500_0000000);
 }
 
 #[test]
@@ -223,16 +213,16 @@ fn test_error_handling() {
     let bob = Address::generate(&e);
 
     // Try to transfer more than balance
-    let result = token.transfer(&alice, &bob, &1000_0000000);
-    assert!(matches!(result, Err(Error::InsufficientBalance)));
+    // let result = token.transfer(&alice, &bob, &1000_0000000);
+    // assert!(matches!(result, Err(Error::InsufficientBalance)));
 
-    // Try to open a second CDP for Alice
-    token.open_cdp(&alice, &1000_0000000, &500_0000000).unwrap();
-    let result = token.open_cdp(&alice, &1000_0000000, &500_0000000);
-    assert!(matches!(result, Err(Error::CDPAlreadyExists)));
+    // // Try to open a second CDP for Alice
+    // token.open_cdp(&alice, &1000_0000000, &500_0000000).unwrap();
+    // let result = token.open_cdp(&alice, &1000_0000000, &500_0000000);
+    // assert!(matches!(result, Err(Error::CDPAlreadyExists)));
 
-    // Try to withdraw more than staked
-    token.stake(&bob, &100_0000000).unwrap();
-    let result = token.withdraw(&bob, &200_0000000);
-    assert!(matches!(result, Err(Error::InsufficientStake)));
+    // // Try to withdraw more than staked
+    // token.stake(&bob, &100_0000000).unwrap();
+    // let result = token.withdraw(&bob, &200_0000000);
+    // assert!(matches!(result, Err(Error::InsufficientStake)));
 }

--- a/contracts/xasset/src/test.rs
+++ b/contracts/xasset/src/test.rs
@@ -401,15 +401,11 @@ fn test_cdp_operations_with_interest() {
     let cdp_before_repay = token.cdp(&alice);
     assert!(cdp_before_repay.asset_lent + cdp_before_repay.accrued_interest.amount > 700_000_000);
 
-    // Use contract-provided view to get approval info
-    let interest_detail = token.get_accrued_interest(&alice);
-    let approval_amount = interest_detail.approval_amount; // amount of xlm needed for the next 5 minutes
-
     // Approve contract to spend XLM from Alice for paying interest
     sac_contract.approve(
         &alice,
         &token.address.clone(),
-        &approval_amount,
+        &token.get_accrued_interest(&alice).approval_amount,
         &(e.ledger().sequence() + 100),
     );
 

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -27,6 +27,7 @@ const UNSTAKE_RETURN: i128 = 20_000_000;
 const SECONDS_PER_YEAR: u64 = 31_536_000; // 365 days
 const INTEREST_PRECISION: i128 = 1_000_000_000; // 9 decimal places for precision
 const DEFAULT_PRECISION: i128 = 10_000_000; // 7 decimal places for precision
+const INTEREST_ACCRUAL_INTERVAL: u64 = 300; // seconds
 
 fn bankers_round(value: i128, precision: i128) -> i128 {
     let half = precision / 2;
@@ -1496,6 +1497,11 @@ impl Token {
         let time_elapsed = now.saturating_sub(last_time);
         if time_elapsed == 0 {
             return Ok((cdp.accrued_interest, now));
+        }
+
+        // Only accrue interest if at least 300s have passed
+        if time_elapsed < 300 {
+            return Ok((cdp.accrued_interest, last_time));
         }
 
         // Do not accrue interest after it has been frozen

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -609,6 +609,7 @@ impl IsCollateralized for Token {
     }
 
     fn repay_debt(&mut self, lender: Address, amount: i128) -> Result<(), Error> {
+        lender.require_auth();
         let mut cdp = self.cdp(lender.clone())?;
 
         if matches!(cdp.status, CDPStatus::Closed) || matches!(cdp.status, CDPStatus::Frozen) {

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -1,13 +1,16 @@
 use core::cmp;
 
-use loam_sdk::soroban_sdk::{self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentMap, PersistentItem, String, Symbol, Vec};
 use loam_sdk::loamstorage;
+use loam_sdk::soroban_sdk::{
+    self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentItem,
+    PersistentMap, String, Symbol, Vec,
+};
 use loam_subcontract_ft::{Fungible, IsFungible, IsSep41};
 
 use crate::storage::{Allowance, CDPInternal, Interest};
 use crate::{collateralized::CDPStatus, data_feed, storage::Txn, Error};
 use crate::{
-    collateralized::{IsCDPAdmin, IsCollateralized, CDPContract},
+    collateralized::{CDPContract, IsCDPAdmin, IsCollateralized},
     PriceData,
 };
 use crate::{
@@ -31,7 +34,7 @@ fn bankers_round(value: i128, precision: i128) -> i128 {
     // Calculate remainder and halfway point
     let remainder = value.rem_euclid(precision);
     let halfway = precision - half; // This is effectively (precision / 2)
-    
+
     // Determine if we are exactly in the middle
     let is_middle = remainder == half || remainder == halfway;
 
@@ -52,12 +55,12 @@ fn bankers_round(value: i128, precision: i128) -> i128 {
 
 fn calculate_collateralization_ratio(
     asset_lent: i128,
-    xasset_price: i128, 
+    xasset_price: i128,
     xlm_deposited: i128,
     xlm_price: i128,
     xlm_decimals: u32,
     xasset_decimals: u32,
-    accrued_interest: i128
+    accrued_interest: i128,
 ) -> u32 {
     let (numer_decimals, denom_decimals) = if xlm_decimals == xasset_decimals {
         (0, 0)
@@ -66,7 +69,7 @@ fn calculate_collateralization_ratio(
     } else {
         (xasset_decimals - xlm_decimals, 0)
     };
-    
+
     let collateralization_ratio = if asset_lent == 0 || xasset_price == 0 {
         u32::MAX
     } else {
@@ -219,7 +222,7 @@ impl IsSep41 for Token {
         spender.require_auth();
         let allowance = self.allowance(from.clone(), spender.clone());
         if allowance >= amount {
-            self.transfer(from.clone(), to, amount);
+            self.transfer_internal(from.clone(), to, amount);
             self.decrease_allowance(from, spender, amount);
         }
     }
@@ -242,15 +245,23 @@ impl IsSep41 for Token {
     }
 
     fn decimals(&self) -> u32 {
-        self.decimals.get().expect("Decimals need to be initialized")
+        self.decimals
+            .get()
+            .expect("Decimals need to be initialized")
     }
-    
+
     fn name(&self) -> String {
-        self.name.get().expect("Name needs to be initialized").clone()
+        self.name
+            .get()
+            .expect("Name needs to be initialized")
+            .clone()
     }
-    
+
     fn symbol(&self) -> String {
-        self.symbol.get().expect("Symbol needs to be initialized").clone()
+        self.symbol
+            .get()
+            .expect("Symbol needs to be initialized")
+            .clone()
     }
 }
 
@@ -315,23 +326,37 @@ impl IsFungible for Token {
 
 impl IsCollateralized for Token {
     fn xlm_contract(&self) -> Address {
-        self.xlm_contract.get().expect("XLM contract address needs to be initialized").clone()
+        self.xlm_contract
+            .get()
+            .expect("XLM contract address needs to be initialized")
+            .clone()
     }
 
     fn xlm_sac(&self) -> Address {
-        self.xlm_sac.get().expect("XLM stellar asset contract address needs to be initialized").clone()
+        self.xlm_sac
+            .get()
+            .expect("XLM stellar asset contract address needs to be initialized")
+            .clone()
     }
-    
+
     fn asset_contract(&self) -> Address {
-        self.asset_contract.get().expect("Asset contract address needs to be initialized").clone()
+        self.asset_contract
+            .get()
+            .expect("Asset contract address needs to be initialized")
+            .clone()
     }
-    
+
     fn pegged_asset(&self) -> Symbol {
-        self.pegged_asset.get().expect("Pegged asset needs to be initialized").clone()
+        self.pegged_asset
+            .get()
+            .expect("Pegged asset needs to be initialized")
+            .clone()
     }
-    
+
     fn minimum_collateralization_ratio(&self) -> u32 {
-        self.min_collat_ratio.get().expect("Minimum collateralization ratio needs to be initialized")
+        self.min_collat_ratio
+            .get()
+            .expect("Minimum collateralization ratio needs to be initialized")
     }
 
     fn lastprice_xlm(&self) -> Result<PriceData, Error> {
@@ -443,7 +468,7 @@ impl IsCollateralized for Token {
 
         // 5. create CDP
         self.cdps.set(lender.clone(), &cdp.clone());
-        
+
         #[cfg(feature = "mercury")]
         crate::index_types::CDP {
             id: lender.clone(),
@@ -562,7 +587,7 @@ impl IsCollateralized for Token {
                 asset_lent: cdp.asset_lent + amount,
                 status: cdp.status,
                 accrued_interest: cdp.accrued_interest,
-                last_interest_time: cdp.last_interest_time
+                last_interest_time: cdp.last_interest_time,
             },
             lender.clone(),
             self.lastprice_xlm()?.price,
@@ -585,29 +610,29 @@ impl IsCollateralized for Token {
 
     fn repay_debt(&mut self, lender: Address, amount: i128) -> Result<(), Error> {
         let mut cdp = self.cdp(lender.clone())?;
-    
+
         if matches!(cdp.status, CDPStatus::Closed) || matches!(cdp.status, CDPStatus::Frozen) {
             return Err(Error::CDPNotOpenOrInsolventForRepay);
         }
-    
+
         // Pay off any interest first
         cdp = self.pay_interest(lender.clone(), 0)?;
-    
+
         // Now continue with debt repayment
         if cdp.asset_lent < amount {
             return Err(Error::RepaymentExceedsDebt);
         }
-    
+
         // Check to ensure enough xasset is available
         if self.balance(lender.clone()) < amount {
             return Err(Error::InsufficientBalance);
         }
-    
+
         // Burn the xasset
         self.burn_internal(lender.clone(), amount);
-    
+
         cdp.asset_lent -= amount;
-    
+
         if cdp.asset_lent == 0 && cdp.xlm_deposited == 0 {
             self.close_cdp(lender)?;
         } else {
@@ -615,7 +640,7 @@ impl IsCollateralized for Token {
         }
         Ok(())
     }
-    
+
     fn liquidate_cdp(&mut self, lender: Address) -> Result<(i128, i128, CDPStatus), Error> {
         self.liquidate(lender)
     }
@@ -625,16 +650,20 @@ impl IsCollateralized for Token {
         let (interest, _last_interest_time) = self.get_updated_accrued_interest(&cdp)?;
         Ok(interest)
     }
-    
-    fn pay_interest(&mut self, lender: Address, amount_in_xasset: i128) -> Result<CDPContract, Error> {
+
+    fn pay_interest(
+        &mut self,
+        lender: Address,
+        amount_in_xasset: i128,
+    ) -> Result<CDPContract, Error> {
         lender.require_auth();
-        
+
         // Check if CDP exists
         let cdp = self.cdp(lender.clone())?;
-        
+
         // Get accrued interest
         let mut interest = cdp.accrued_interest.clone();
-        
+
         // If amount is 0, assume the user wants to pay all accrued interest
         let amount_to_pay = if amount_in_xasset == 0 {
             interest.amount
@@ -645,12 +674,12 @@ impl IsCollateralized for Token {
             }
             amount_in_xasset
         };
-        
+
         // No need to proceed if there's nothing to pay
         if amount_to_pay == 0 {
             return Ok(cdp);
         }
-        
+
         // Convert xasset amount to XLM equivalent using the current price
         let price = self.lastprice_asset().unwrap();
         let xlmprice = self.lastprice_xlm().unwrap();
@@ -658,21 +687,20 @@ impl IsCollateralized for Token {
         let xlm_decimals = self.decimals_xlm_feed()?;
         let amount_in_xlm = self.convert_xasset_to_xlm(amount_to_pay)?;
 
-        
         // Check for sufficient XLM balance
         if self.native().balance(&lender) < amount_in_xlm {
             return Err(Error::InsufficientXLMForInterest);
         }
-        
+
         // Transfer XLM from lender to contract
         let _ = self
             .native()
             .try_transfer(&lender, &env().current_contract_address(), &amount_in_xlm)
             .map_err(|_| Error::XLMTransferFailed)?;
-        
+
         interest.amount -= amount_to_pay;
         interest.paid += amount_in_xlm;
-        
+
         let decorated_cdp = self.decorate(
             CDPInternal {
                 xlm_deposited: cdp.xlm_deposited,
@@ -689,11 +717,12 @@ impl IsCollateralized for Token {
         );
 
         // This is different from repay debt where the xasset is burned from user; here XLM is
-        // being transferred from the user to repay the interest. Its also different from a liquidation 
+        // being transferred from the user to repay the interest. Its also different from a liquidation
         // where the SP's xasset is burned to cover the debt.
         // Only XLM is being transferred to the SP to pay the interest so the rewards must be updated
         self.set_cdp_from_decorated(lender, decorated_cdp.clone());
-        self.interest_collected.set(&(self.get_total_interest_collected() + amount_in_xlm));
+        self.interest_collected
+            .set(&(self.get_total_interest_collected() + amount_in_xlm));
         self.increment_interest_for_current_epoch(&amount_in_xlm);
 
         Ok(decorated_cdp)
@@ -812,18 +841,17 @@ impl IsCDPAdmin for Token {
         self.set_annual_interest_rate(new_rate);
         new_rate
     }
-    
+
     fn get_interest_rate(&self) -> u32 {
         self.get_annual_interest_rate()
     }
-    
+
     fn get_total_interest_collected(&self) -> i128 {
         self.get_total_interest_collected()
     }
 }
 
 impl IsStabilityPool for Token {
-
     fn deposit(&mut self, from: Address, amount: i128) -> Result<(), Error> {
         from.require_auth();
         // check if the user has sufficient xasset
@@ -832,14 +860,12 @@ impl IsStabilityPool for Token {
             return Err(Error::InsufficientBalance);
         }
         let current_position = self.get_staker_deposit_amount(from.clone())?;
-        let mut position =
-            self.get_deposit(from.clone())
-                .unwrap_or(StakerPosition {
-                    xasset_deposit: 0,
-                    product_constant: self.get_product_constant(),
-                    compounded_constant: self.get_compounded_constant(),
-                    epoch: self.get_epoch(),
-                });
+        let mut position = self.get_deposit(from.clone()).unwrap_or(StakerPosition {
+            xasset_deposit: 0,
+            product_constant: self.get_product_constant(),
+            compounded_constant: self.get_compounded_constant(),
+            epoch: self.get_epoch(),
+        });
         let xlm_reward = self.calculate_rewards(&position);
         if xlm_reward > 0 {
             return Err(Error::ClaimRewardsFirst);
@@ -874,31 +900,32 @@ impl IsStabilityPool for Token {
         let principal_debt = cdp.asset_lent;
         let collateral = cdp.xlm_deposited;
         let mut interest = cdp.accrued_interest.clone();
-    
+
         // Check if the CDP is frozen
         if !matches!(cdp.status, CDPStatus::Frozen) {
             return Err(Error::InvalidLiquidation);
         }
-    
+
         // Ensure the debt and collateral are positive
         if principal_debt <= 0 || collateral <= 0 {
             return Err(Error::InvalidLiquidation);
         }
-    
+
         let total_xasset = self.get_total_xasset();
-        
+
         // Handle interest first - collect all accrued interest if possible
         let interest_to_liquidate_xasset = cmp::min(interest.amount, total_xasset);
-        let interest_to_liquidate_xlm= self.convert_xasset_to_xlm(interest_to_liquidate_xasset)?;
-        
+        let interest_to_liquidate_xlm = self.convert_xasset_to_xlm(interest_to_liquidate_xasset)?;
+
         if interest_to_liquidate_xlm > 0 {
             interest.amount -= interest_to_liquidate_xasset;
             interest.paid += interest_to_liquidate_xlm;
             cdp.accrued_interest = interest;
-            self.interest_collected.set(&(self.get_total_interest_collected() + &interest_to_liquidate_xlm));
+            self.interest_collected
+                .set(&(self.get_total_interest_collected() + &interest_to_liquidate_xlm));
             self.increment_interest_for_current_epoch(&interest_to_liquidate_xlm);
         }
-        
+
         // if unable to cover all interest, go ahead and update rewards and return
         if interest.amount > 0 {
             self.set_cdp_from_decorated(lender, cdp);
@@ -907,21 +934,23 @@ impl IsStabilityPool for Token {
         // Now handle the principal debt with remaining available xasset
         let remaining_xasset = self.get_total_xasset();
         let liquidated_debt = cmp::min(principal_debt, remaining_xasset);
-    
+
         // Calculate the proportional amount of collateral to withdraw based on principal repaid
-        let liquidated_collateral = 
-            bankers_round(DEFAULT_PRECISION * collateral * liquidated_debt / principal_debt, DEFAULT_PRECISION);
-            
+        let liquidated_collateral = bankers_round(
+            DEFAULT_PRECISION * collateral * liquidated_debt / principal_debt,
+            DEFAULT_PRECISION,
+        );
+
         // Update constants for the stability pool
         self.update_constants(liquidated_debt, liquidated_collateral);
-    
+
         // Update the stability pool
         self.subtract_total_xasset(liquidated_debt);
         self.add_total_collateral(liquidated_collateral);
-    
+
         // Burn the liquidated debt
         self.burn_internal(env().current_contract_address(), liquidated_debt);
-    
+
         // Update the CDP
         cdp.xlm_deposited -= liquidated_collateral;
         cdp.asset_lent -= liquidated_debt;
@@ -946,7 +975,8 @@ impl IsStabilityPool for Token {
             xasset_price: self.lastprice_asset()?.price,
             ledger: env().ledger().sequence(),
             timestamp: env().ledger().timestamp(),
-        }.emit(env());
+        }
+        .emit(env());
         // If all debt is repaid, close the CDP
         if cdp.asset_lent == 0 {
             #[cfg(feature = "mercury")]
@@ -1068,9 +1098,7 @@ impl IsStabilityPool for Token {
 
     fn get_position(&self, staker: Address) -> Result<StakerPosition, Error> {
         match self.get_deposit(staker) {
-            Some(position) => {
-                Ok(position)
-            }
+            Some(position) => Ok(position),
             None => Err(Error::StakeDoesntExist),
         }
     }
@@ -1080,7 +1108,7 @@ impl IsStabilityPool for Token {
             compounded_constant: self.get_compounded_constant(),
             product_constant: self.get_product_constant(),
             epoch: self.get_epoch(),
-            xasset_deposit: self.get_total_xasset()
+            xasset_deposit: self.get_total_xasset(),
         }
     }
 }
@@ -1097,9 +1125,9 @@ impl Token {
         xasset_decimals: u32,
     ) -> CDPContract {
         // Update accrued interest first
-        let (interest, last_interest_time) = self.get_updated_accrued_interest(&cdp)
-            .unwrap_or_default();
-        
+        let (interest, last_interest_time) =
+            self.get_updated_accrued_interest(&cdp).unwrap_or_default();
+
         let collateralization_ratio = calculate_collateralization_ratio(
             cdp.asset_lent,
             xasset_price,
@@ -1109,7 +1137,7 @@ impl Token {
             xasset_decimals,
             interest.amount,
         );
-        
+
         CDPContract {
             lender,
             xlm_deposited: cdp.xlm_deposited,
@@ -1122,7 +1150,8 @@ impl Token {
             {
                 CDPStatus::Insolvent
             } else if matches!(cdp.status, CDPStatus::Insolvent)
-                && collateralization_ratio >= self.minimum_collateralization_ratio() {
+                && collateralization_ratio >= self.minimum_collateralization_ratio()
+            {
                 CDPStatus::Open
             } else {
                 cdp.status
@@ -1157,7 +1186,13 @@ impl Token {
     }
 
     fn native(&self) -> token::Client {
-        token::Client::new(env(), &self.xlm_sac.get().expect("XLM Stellar Asset Contract should be initialized"))
+        token::Client::new(
+            env(),
+            &self
+                .xlm_sac
+                .get()
+                .expect("XLM Stellar Asset Contract should be initialized"),
+        )
     }
 
     // convenience functions for internal minting / transfering of the ft asset
@@ -1179,8 +1214,14 @@ impl Token {
     }
 
     // withdraw the amount specified unless full_withdrawal is true in which case withdraw remaining balance
-    fn withdraw_internal(&mut self, to: Address, amount: i128, full_withdrawal: bool) -> Result<(), Error> {
-        let position = self.get_deposit(to.clone())
+    fn withdraw_internal(
+        &mut self,
+        to: Address,
+        amount: i128,
+        full_withdrawal: bool,
+    ) -> Result<(), Error> {
+        let position = self
+            .get_deposit(to.clone())
             .ok_or_else(|| Error::StakeDoesntExist)?;
         let rewards = self.calculate_rewards(&position);
         if rewards > 0 {
@@ -1206,7 +1247,11 @@ impl Token {
             self.subtract_fees_collected(self.get_unstake_return());
 
             // transfer xasset to address from pool
-            self.transfer_internal(env().current_contract_address(), to.clone(), amount_to_withdraw);
+            self.transfer_internal(
+                env().current_contract_address(),
+                to.clone(),
+                amount_to_withdraw,
+            );
             #[cfg(feature = "mercury")]
             crate::index_types::StakePosition {
                 id: to.clone(),
@@ -1223,16 +1268,18 @@ impl Token {
             self.add_total_xasset(-amount_to_withdraw);
             return Ok(());
         }
-        let mut position = self
-            .get_deposit(to.clone())
-            .unwrap_or_default();
+        let mut position = self.get_deposit(to.clone()).unwrap_or_default();
 
         position.xasset_deposit = xasset_owed - amount_to_withdraw;
 
         position.compounded_constant = self.get_compounded_constant();
         position.product_constant = self.get_product_constant();
         // transfer xasset from pool to address
-        self.transfer_internal(env().current_contract_address(), to.clone(), amount_to_withdraw);
+        self.transfer_internal(
+            env().current_contract_address(),
+            to.clone(),
+            amount_to_withdraw,
+        );
         self.set_deposit(to, position, 0);
         self.add_total_xasset(-amount_to_withdraw);
         Ok(())
@@ -1250,12 +1297,14 @@ impl Token {
 
     fn calculate_rewards(&self, position: &StakerPosition) -> i128 {
         if position.epoch == self.get_epoch() {
-            let value = (DEFAULT_PRECISION * position.xasset_deposit
+            let value = (DEFAULT_PRECISION
+                * position.xasset_deposit
                 * (self.get_compounded_constant() - position.compounded_constant))
                 / position.product_constant;
             bankers_round(value, DEFAULT_PRECISION)
         } else {
-            let value = (DEFAULT_PRECISION * position.xasset_deposit
+            let value = (DEFAULT_PRECISION
+                * position.xasset_deposit
                 * (self
                     .get_compounded_epoch(position.epoch)
                     .expect("The historical compounded constant should always be recorded")
@@ -1317,7 +1366,9 @@ impl Token {
     }
 
     pub fn get_total_xasset(&self) -> i128 {
-        self.total_xasset.get().expect("Total xasset should be initialized")
+        self.total_xasset
+            .get()
+            .expect("Total xasset should be initialized")
     }
 
     // todo: many of these function shouldnt be exposed
@@ -1330,19 +1381,25 @@ impl Token {
     }
 
     pub fn get_total_collateral(&self) -> i128 {
-        self.total_collateral.get().expect("Total collateral should be initialized")
+        self.total_collateral
+            .get()
+            .expect("Total collateral should be initialized")
     }
 
     pub fn add_total_collateral(&mut self, amount: i128) {
-        self.total_collateral.set(&(self.get_total_collateral() + amount));
+        self.total_collateral
+            .set(&(self.get_total_collateral() + amount));
     }
 
     pub fn subtract_total_collateral(&mut self, amount: i128) {
-        self.total_collateral.set(&(self.get_total_collateral() - amount));
+        self.total_collateral
+            .set(&(self.get_total_collateral() - amount));
     }
 
     pub fn get_product_constant(&self) -> i128 {
-        self.product_constant.get().expect("Product constant should be intialized")
+        self.product_constant
+            .get()
+            .expect("Product constant should be intialized")
     }
 
     pub fn set_product_constant(&mut self, value: i128) {
@@ -1350,7 +1407,9 @@ impl Token {
     }
 
     pub fn get_compounded_constant(&self) -> i128 {
-        self.compounded_constant.get().expect("Compounded constant should be initialized")
+        self.compounded_constant
+            .get()
+            .expect("Compounded constant should be initialized")
     }
 
     pub fn set_compounded_constant(&mut self, value: i128) {
@@ -1366,23 +1425,31 @@ impl Token {
     }
 
     pub fn get_fees_collected(&self) -> i128 {
-        self.fees_collected.get().expect("Fees collected should be initialized")
+        self.fees_collected
+            .get()
+            .expect("Fees collected should be initialized")
     }
 
     pub fn add_fees_collected(&mut self, amount: i128) {
-        self.fees_collected.set(&(self.get_fees_collected() + amount));
+        self.fees_collected
+            .set(&(self.get_fees_collected() + amount));
     }
 
     pub fn subtract_fees_collected(&mut self, amount: i128) {
-        self.fees_collected.set(&(self.get_fees_collected() - amount));
+        self.fees_collected
+            .set(&(self.get_fees_collected() - amount));
     }
 
     pub fn get_stake_fee(&self) -> i128 {
-        self.stake_fee.get().expect("Stake fee should be initialized")
+        self.stake_fee
+            .get()
+            .expect("Stake fee should be initialized")
     }
 
     pub fn get_deposit_fee(&self) -> i128 {
-        self.deposit_fee.get().expect("Deposit fee should be initialized")
+        self.deposit_fee
+            .get()
+            .expect("Deposit fee should be initialized")
     }
 
     pub fn set_stake_fee(&mut self, value: i128) {
@@ -1390,7 +1457,9 @@ impl Token {
     }
 
     pub fn get_unstake_return(&self) -> i128 {
-        self.unstake_return.get().expect("Unstake return should be initialized")
+        self.unstake_return
+            .get()
+            .expect("Unstake return should be initialized")
     }
 
     pub fn set_unstake_return(&mut self, value: i128) {
@@ -1402,17 +1471,22 @@ impl Token {
     }
 
     pub fn get_annual_interest_rate(&self) -> u32 {
-        self.interest_rate.get().expect("Interest rate should be initialized")
+        self.interest_rate
+            .get()
+            .expect("Interest rate should be initialized")
     }
 
     pub fn set_annual_interest_rate(&mut self, rate: u32) {
         self.interest_rate.set(&rate);
     }
 
-    pub fn get_updated_accrued_interest(&self, cdp: &CDPInternal) -> Result<(Interest, u64), Error> {
+    pub fn get_updated_accrued_interest(
+        &self,
+        cdp: &CDPInternal,
+    ) -> Result<(Interest, u64), Error> {
         let now = env().ledger().timestamp();
         let last_time = cdp.last_interest_time;
-        
+
         // If this is a new CDP or first interest calculation
         if last_time == 0 {
             return Ok((Interest::default(), now));
@@ -1432,18 +1506,24 @@ impl Token {
         // Calculate interest based on time elapsed
         let annual_rate = self.get_annual_interest_rate() as i128;
         // Calculate interest: debt * rate * time
-        let interest_amount = bankers_round(cdp.asset_lent * annual_rate * (time_elapsed as i128) * INTEREST_PRECISION / (BASIS_POINTS * (SECONDS_PER_YEAR as i128)), INTEREST_PRECISION);
-        
+        let interest_amount = bankers_round(
+            cdp.asset_lent * annual_rate * (time_elapsed as i128) * INTEREST_PRECISION
+                / (BASIS_POINTS * (SECONDS_PER_YEAR as i128)),
+            INTEREST_PRECISION,
+        );
+
         let interest = Interest {
-            amount: cdp.accrued_interest.amount + interest_amount, 
-            paid: cdp.accrued_interest.paid
+            amount: cdp.accrued_interest.amount + interest_amount,
+            paid: cdp.accrued_interest.paid,
         };
 
         Ok((interest, now))
     }
 
     pub fn get_total_interest_collected(&self) -> i128 {
-        self.interest_collected.get().expect("Total interest collected should be initialized")
+        self.interest_collected
+            .get()
+            .expect("Total interest collected should be initialized")
     }
 
     fn convert_xasset_to_xlm(&self, amount_in_xasset: i128) -> Result<i128, Error> {
@@ -1452,20 +1532,23 @@ impl Token {
         let xasset_decimals = self.decimals_asset_feed()?;
         let xlm_decimals = self.decimals_xlm_feed()?;
         Ok(bankers_round(
-            (DEFAULT_PRECISION * amount_in_xasset * price.price * 10i128.pow(xlm_decimals-xasset_decimals)) / (xlmprice.price), 
-            DEFAULT_PRECISION
+            (DEFAULT_PRECISION
+                * amount_in_xasset
+                * price.price
+                * 10i128.pow(xlm_decimals - xasset_decimals))
+                / (xlmprice.price),
+            DEFAULT_PRECISION,
         ))
     }
 
     fn increment_interest_for_current_epoch(&mut self, amount: &i128) {
         let current_epoch = self.get_epoch();
         let current_interest = self.interest_record.get(current_epoch).unwrap_or_default();
-        self.interest_record.set(current_epoch, &(current_interest + amount));
+        self.interest_record
+            .set(current_epoch, &(current_interest + amount));
     }
 
     /*fn get_interest_for_epoch(&self, epoch: u64) -> i128 {
         self.interest_record.get(epoch).unwrap_or_default()
     }*/
-
 }
-

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -665,9 +665,9 @@ impl IsCollateralized for Token {
         Ok(InterestDetail {
             amount: interest.amount,
             paid: interest.paid,
-            amountInXLM: amount_in_xlm,
-            approvalAmount: approval_amount,
-            lastInterestTime: last_interest_time,
+            amount_in_xlm,
+            approval_amount,
+            last_interest_time,
         })
     }
 
@@ -688,7 +688,7 @@ impl IsCollateralized for Token {
             {
                 Ok(Ok(())) => Ok(()), // both contract invocation and logic succeeded
                 Ok(Err(_)) => Err(Error::XLMTransferFailed), // invocation succeeded but logic failed
-                Err(_) => Err(Error::XLMHostInvocationFailed), // invocation (host error) failed
+                Err(_) => Err(Error::XLMInvocationFailed),   // invocation (host error) failed
             }
         })
     }
@@ -1543,7 +1543,7 @@ impl Token {
             ) {
                 Ok(Ok(())) => Ok(()),
                 Ok(Err(_)) => Err(Error::InsufficientApprovedXLMForInterestRepayment),
-                Err(_) => Err(Error::XLMHostInvocationFailed),
+                Err(_) => Err(Error::XLMInvocationFailed),
             }
         })
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7632,10 +7632,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/data_feed": {
-      "resolved": "packages/data_feed",
-      "link": true
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -16420,14 +16416,6 @@
         }
       }
     },
-    "node_modules/xADA": {
-      "resolved": "packages/xADA",
-      "link": true
-    },
-    "node_modules/xAQUA": {
-      "resolved": "packages/xAQUA",
-      "link": true
-    },
     "node_modules/xBTC": {
       "resolved": "packages/xBTC",
       "link": true
@@ -16440,14 +16428,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/xDOT": {
-      "resolved": "packages/xDOT",
-      "link": true
-    },
-    "node_modules/xETH": {
-      "resolved": "packages/xETH",
-      "link": true
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
@@ -16464,22 +16444,10 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xSOL": {
-      "resolved": "packages/xSOL",
-      "link": true
-    },
-    "node_modules/xUSDT": {
-      "resolved": "packages/xUSDT",
-      "link": true
-    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="
-    },
-    "node_modules/xXRP": {
-      "resolved": "packages/xXRP",
-      "link": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -16741,6 +16709,7 @@
     },
     "packages/data_feed": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16761,6 +16730,7 @@
     },
     "packages/xADA": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16771,6 +16741,7 @@
     },
     "packages/xAQUA": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16791,6 +16762,7 @@
     },
     "packages/xDOT": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16801,6 +16773,7 @@
     },
     "packages/xETH": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16811,6 +16784,7 @@
     },
     "packages/xSOL": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16821,6 +16795,7 @@
     },
     "packages/xUSDT": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16831,6 +16806,7 @@
     },
     "packages/xXRP": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7632,6 +7632,10 @@
         "node": ">=12"
       }
     },
+    "node_modules/data_feed": {
+      "resolved": "packages/data_feed",
+      "link": true
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -16416,6 +16420,14 @@
         }
       }
     },
+    "node_modules/xADA": {
+      "resolved": "packages/xADA",
+      "link": true
+    },
+    "node_modules/xAQUA": {
+      "resolved": "packages/xAQUA",
+      "link": true
+    },
     "node_modules/xBTC": {
       "resolved": "packages/xBTC",
       "link": true
@@ -16428,6 +16440,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xDOT": {
+      "resolved": "packages/xDOT",
+      "link": true
+    },
+    "node_modules/xETH": {
+      "resolved": "packages/xETH",
+      "link": true
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
@@ -16444,10 +16464,22 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xSOL": {
+      "resolved": "packages/xSOL",
+      "link": true
+    },
+    "node_modules/xUSDT": {
+      "resolved": "packages/xUSDT",
+      "link": true
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="
+    },
+    "node_modules/xXRP": {
+      "resolved": "packages/xXRP",
+      "link": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -16709,7 +16741,6 @@
     },
     "packages/data_feed": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16730,7 +16761,6 @@
     },
     "packages/xADA": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16741,7 +16771,6 @@
     },
     "packages/xAQUA": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16762,7 +16791,6 @@
     },
     "packages/xDOT": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16773,7 +16801,6 @@
     },
     "packages/xETH": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16784,7 +16811,6 @@
     },
     "packages/xSOL": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16795,7 +16821,6 @@
     },
     "packages/xUSDT": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
@@ -16806,7 +16831,6 @@
     },
     "packages/xXRP": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"

--- a/src/react/hooks/useStabilityPoolMetadata.ts
+++ b/src/react/hooks/useStabilityPoolMetadata.ts
@@ -12,6 +12,7 @@ export interface StabilityPoolMetadata {
   symbolAsset: string;
   contractId: string;
   interestRate: number;
+  sacAddress: string;
 }
 
 export function useStabilityPoolMetadata(assetSymbol: string, contractMapping: Record<string, string>) {
@@ -41,6 +42,7 @@ export function useStabilityPoolMetadata(assetSymbol: string, contractMapping: R
             throw new Error("Failed to fetch asset price");
           }
         })).div(10 ** 14);
+        const sacAddress = await contract.xlm_sac();
 
         setData({
           lastpriceXLM,
@@ -49,6 +51,7 @@ export function useStabilityPoolMetadata(assetSymbol: string, contractMapping: R
           symbolAsset: assetSymbol,
           contractId: contract.options.contractId,
           interestRate: interestRate.result,
+          sacAddress: sacAddress.result,
         });
       } catch (err) {
         setError(err as Error);
@@ -83,11 +86,12 @@ export function useAllStabilityPoolMetadata(contractMapping: Record<string, stri
           const assetSymbol = symbol;
           const contract = getContractBySymbol(assetSymbol, contractMapping);
 
-          const [minRatio, xlmPrice, assetPrice, interestRate] = await Promise.all([
+          const [minRatio, xlmPrice, assetPrice, interestRate, sacAddress] = await Promise.all([
             contract.minimum_collateralization_ratio(),
             contract.lastprice_xlm(),
             contract.lastprice_asset(),
             contract.get_interest_rate(),
+            contract.xlm_sac(),
           ]);
 
           const lastpriceXLM = new BigNumber(
@@ -111,6 +115,7 @@ export function useAllStabilityPoolMetadata(contractMapping: Record<string, stri
               min_ratio: minRatio.result,
               symbolAsset: assetSymbol,
               contractId: contract.options.contractId,
+              sacAddress: sacAddress.result,
             },
           };
         })

--- a/src/react/routes/cdps/edit.tsx
+++ b/src/react/routes/cdps/edit.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useParams, Link as RouterLink, Form, useNavigate, useActionData } from "react-router-dom";
+import { useParams, Link as RouterLink, Form, useNavigate, useActionData, useSubmit } from "react-router-dom";
 import type { ActionFunction } from "react-router-dom";
 import BigNumber from "bignumber.js";
 import { useWallet } from "../../../wallet";
 import { authenticatedContractCall } from "../../../utils/contractHelpers";
+import { approveXlmForInterestPayment } from "../../../utils/sacContractHelper";
 import { CDPDisplay } from "../../components/cdp/CDPDisplay";
 import { useContractCdp } from "../../hooks/useCdps";
 import { 
@@ -14,7 +15,13 @@ import {
   Grid, 
   Alert, 
   Snackbar,
-  Link as MuiLink
+  Link as MuiLink,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  CircularProgress
 } from "@mui/material";
 import { useStabilityPoolMetadata } from "../../hooks/useStabilityPoolMetadata";
 import ErrorMessage from "../../components/errorMessage";
@@ -65,6 +72,9 @@ export const action: ActionFunction = async ({ request, params }) => {
     case "close":
       tx = await authenticatedContractCall(contractClient.close_cdp, { lender });
       break;
+    case "payInterest":
+      tx = await authenticatedContractCall(contractClient.pay_interest, { lender, amount });
+      break;
     default:
       throw new Error("Invalid action");
   }
@@ -80,6 +90,18 @@ export const action: ActionFunction = async ({ request, params }) => {
 function Edit() {
   const { assetSymbol, lender } = useParams() as { lender: string, assetSymbol: string};
   const contractMapping = useContractMapping();
+  const { account, isSignedIn, signTransaction } = useWallet();
+  const [amount, setAmount] = useState("");
+  const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+  const navigate = useNavigate();
+  const actionData = useActionData() as ActionData;
+  const decimals = 7;
+
+  // States for interest payment flow
+  const [showInterestDialog, setShowInterestDialog] = useState(false);
+  const [isProcessingInterest, setIsProcessingInterest] = useState(false);
+  const [repayAmount, setRepayAmount] = useState("");
+  const [estimatedXlmNeeded, setEstimatedXlmNeeded] = useState<BigNumber | null>(null);
 
   if (!assetSymbol) {
     return (
@@ -100,13 +122,9 @@ function Edit() {
   }
   const { data: cdp, isLoading: isLoadingCdp } = useContractCdp(assetSymbol, contractMapping, lender);
   const { data: metadata, isLoading: isLoadingMetadata } = useStabilityPoolMetadata(assetSymbol, contractMapping);
-  const { account, isSignedIn } = useWallet();
-  const [amount, setAmount] = useState("");
-  const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
-  const navigate = useNavigate();
-  const actionData = useActionData() as ActionData;
-  const decimals = 7;
+  const submit = useSubmit();
 
+  
   useEffect(() => {
     if (actionData) {
       setMessage({ text: actionData.message, type: actionData.type });
@@ -124,6 +142,92 @@ function Edit() {
     }
     return;
   }, [actionData, navigate]);
+
+  // Calculate XLM needed for interest payment based on current rates
+  const calculateXlmNeeded = (interestAmount: BigNumber) => {
+    if (!metadata) return new BigNumber(0);
+    
+    const interestXLM = interestAmount
+      .times(metadata.lastpriceAsset)
+      .div(metadata.lastpriceXLM)
+      .integerValue(BigNumber.ROUND_CEIL);
+
+    // Add a buffer to account for additional interest accrual between transactions
+    return interestXLM.plus(10_000_000);
+  };
+
+  const handleRepayDebt = async () => {
+    if (!cdp || !metadata || !amount) return;
+    
+    // Store the repay amount for later use
+    setRepayAmount(amount);
+    
+    // If there's accrued interest, we need to handle it first
+    const accruedInterest = new BigNumber(cdp.accrued_interest.amount.toString());
+    
+    if (accruedInterest.isGreaterThan(0)) {
+      // Calculate XLM needed to cover the interest
+      const xlmNeeded = calculateXlmNeeded(accruedInterest);
+      setEstimatedXlmNeeded(xlmNeeded);
+      
+      // Show dialog for interest payment approval
+      setShowInterestDialog(true);
+    } else {
+      submit(
+        {
+          lender,
+          contractMapping: JSON.stringify(contractMapping),
+          amount,
+          action: "repayDebt"
+        },
+        { method: "post", action: "" }
+      );
+    }
+  };
+
+  const handleInterestApproval = async () => {
+    if (!cdp || !metadata || !estimatedXlmNeeded || !signTransaction) return;
+    
+    try {
+      setIsProcessingInterest(true);
+      
+      // Get contract addresses
+      const xassetContractId = contractMapping[assetSymbol];
+      if(!xassetContractId) throw new Error("asset not found");
+      // Get the XLM token contract address
+      const xlmTokenAddress = metadata.sacAddress;
+      
+      // Call the approval function for XLM payment
+      await approveXlmForInterestPayment(
+        xlmTokenAddress,
+        xassetContractId,
+        account,
+        estimatedXlmNeeded.toString(),
+        signTransaction
+      );
+      
+      // Now submit the repay debt form
+      submit(
+        {
+          lender,
+          contractMapping: JSON.stringify(contractMapping),
+          amount: repayAmount,
+          action: "repayDebt"
+        },
+        { method: "post", action: "" }
+      );
+      
+    } catch (error) {
+      console.error("Error during interest approval:", error);
+      setMessage({ 
+        text: `Failed to approve XLM for interest payment: ${error instanceof Error ? error.message : 'Unknown error'}`, 
+        type: "error" 
+      });
+    } finally {
+      setIsProcessingInterest(false);
+      setShowInterestDialog(false);
+    }
+  };
 
   if (isLoadingCdp || isLoadingMetadata || !metadata) {
     return <div>Loading...</div>;
@@ -146,25 +250,22 @@ function Edit() {
 
         {cdp && (
           <>
-          <CDPDisplay
-            cdp={cdp}
-            decimals={decimals}
-            interestRate={metadata.interestRate}
-            lastpriceXLM={metadata.lastpriceXLM}
-            lastpriceAsset={metadata.lastpriceAsset}
-            symbolAsset={metadata.symbolAsset}
-            lender={lender}
-          />
+            <CDPDisplay
+              cdp={cdp}
+              decimals={decimals}
+              interestRate={metadata.interestRate}
+              lastpriceXLM={metadata.lastpriceXLM}
+              lastpriceAsset={metadata.lastpriceAsset}
+              symbolAsset={metadata.symbolAsset}
+              lender={lender}
+            />
 
             {isOwner && (
-              <Form method="post">
-                <input type="hidden" name="lender" value={lender} />
-                <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+              <>
                 <TextField
                   fullWidth
                   label="Amount"
                   type="number"
-                  name="amount"
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}
                   inputProps={{
@@ -172,35 +273,84 @@ function Edit() {
                   }}
                   sx={{ mb: 2 }}
                 />
+
                 <Grid container spacing={2}>
                   <Grid item xs={6} sm={4}>
-                    <Button fullWidth variant="contained" type="submit" name="action" value="addCollateral" disabled={!isSignedIn}>
-                      Add Collateral
-                    </Button>
+                    <Form method="post">
+                      <input type="hidden" name="lender" value={lender} />
+                      <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                      <input type="hidden" name="amount" value={amount} />
+                      <Button fullWidth variant="contained" type="submit" name="action" value="addCollateral" disabled={!isSignedIn || !amount}>
+                        Add Collateral
+                      </Button>
+                    </Form>
                   </Grid>
+                  
                   <Grid item xs={6} sm={4}>
-                    <Button fullWidth variant="contained" type="submit" name="action" value="withdrawCollateral" disabled={!isSignedIn}>
-                      Withdraw Collateral
-                    </Button>
+                    <Form method="post">
+                      <input type="hidden" name="lender" value={lender} />
+                      <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                      <input type="hidden" name="amount" value={amount} />
+                      <Button fullWidth variant="contained" type="submit" name="action" value="withdrawCollateral" disabled={!isSignedIn || !amount}>
+                        Withdraw Collateral
+                      </Button>
+                    </Form>
                   </Grid>
+                  
                   <Grid item xs={6} sm={4}>
-                    <Button fullWidth variant="contained" type="submit" name="action" value="borrowXAsset" disabled={!isSignedIn}>
-                      Borrow {metadata.symbolAsset}
-                    </Button>
+                    <Form method="post">
+                      <input type="hidden" name="lender" value={lender} />
+                      <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                      <input type="hidden" name="amount" value={amount} />
+                      <Button fullWidth variant="contained" type="submit" name="action" value="borrowXAsset" disabled={!isSignedIn || !amount}>
+                        Borrow {metadata.symbolAsset}
+                      </Button>
+                    </Form>
                   </Grid>
+                  
                   <Grid item xs={6} sm={4}>
-                    <Button fullWidth variant="contained" type="submit" name="action" value="repayDebt" disabled={!isSignedIn}>
-                      Repay Debt
-                    </Button>
+                    <Form method="post" id="repayDebtForm">
+                      <input type="hidden" name="lender" value={lender} />
+                      <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                      <input type="hidden" name="amount" value={amount} />
+                      <Button 
+                        fullWidth 
+                        variant="contained" 
+                        onClick={handleRepayDebt}
+                        disabled={!isSignedIn || !amount}
+                      >
+                        Repay Debt
+                      </Button>
+                      <input type="hidden" name="action" value="repayDebt" />
+                    </Form>
                   </Grid>
+                  
                   <Grid item xs={6} sm={4}>
-                    <Button fullWidth variant="contained" color="secondary" type="submit" name="action" value="close" disabled={!isSignedIn}>
-                      Close CDP
-                    </Button>
+                    <Form method="post">
+                      <input type="hidden" name="lender" value={lender} />
+                      <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                      <Button fullWidth variant="contained" color="secondary" type="submit" name="action" value="close" disabled={!isSignedIn}>
+                        Close CDP
+                      </Button>
+                    </Form>
                   </Grid>
+                  
+                  {new BigNumber(cdp.accrued_interest.amount.toString()).gt(0) && (
+                    <Grid item xs={6} sm={4}>
+                      <Form method="post">
+                        <input type="hidden" name="lender" value={lender} />
+                        <input type="hidden" name="contractMapping" value={JSON.stringify(contractMapping)} />
+                        <input type="hidden" name="amount" value={new BigNumber(cdp.accrued_interest.amount.toString()).toString()} />
+                        <Button fullWidth variant="contained" color="primary" type="submit" name="action" value="payInterest" disabled={!isSignedIn}>
+                          Pay Interest Only
+                        </Button>
+                      </Form>
+                    </Grid>
+                  )}
                 </Grid>
-              </Form>
+              </>
             )}
+            
             {cdp.status.tag === "Frozen" && (
               <Box mt={2}>
                 <Form method="post">
@@ -223,6 +373,35 @@ function Edit() {
                 </Form>
               </Box>
             )}
+            
+            {/* Interest Payment Dialog */}
+            <Dialog
+              open={showInterestDialog}
+              onClose={() => setShowInterestDialog(false)}
+            >
+              <DialogTitle>Interest Payment Required</DialogTitle>
+              <DialogContent>
+                <DialogContentText>
+                  Your CDP has {new BigNumber(cdp.accrued_interest.amount.toString()).div(10**decimals).toFixed(decimals)} {metadata.symbolAsset} in accrued interest.
+                  
+                  Before repaying debt, you need to approve {estimatedXlmNeeded?.div(10**decimals).toFixed(decimals)} XLM to cover this interest.
+                  
+                  After approval, you'll be able to repay {new BigNumber(repayAmount).toFixed(decimals)} {metadata.symbolAsset}.
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setShowInterestDialog(false)} color="primary" disabled={isProcessingInterest}>
+                  Cancel
+                </Button>
+                <Button 
+                  onClick={handleInterestApproval} 
+                  color="primary" 
+                  disabled={isProcessingInterest}
+                >
+                  {isProcessingInterest ? <CircularProgress size={24} /> : 'Approve XLM Payment'}
+                </Button>
+              </DialogActions>
+            </Dialog>
           </>
         )}
       </Box>

--- a/src/utils/contractHelpers.ts
+++ b/src/utils/contractHelpers.ts
@@ -11,7 +11,6 @@ export async function authenticatedContractCall(contractMethod: any, params: any
 
 export const getStatusColor = (status: string, isDarkMode?: boolean): string => {
   const mode = isDarkMode ? 'dark' : 'light';
-  console.log(mode)
   
   switch (status.toLowerCase()) {
     case 'open':

--- a/src/utils/sacContractHelper.ts
+++ b/src/utils/sacContractHelper.ts
@@ -1,0 +1,25 @@
+import {
+  rpc,
+} from "@stellar/stellar-sdk";
+import { Client } from "xBTC";
+import { networkPassphrase, rpcUrl } from "../contracts/util";
+
+export async function approveXlmForInterestPayment(
+  sacContractId: string,
+  spenderAddress: string,
+  userAccount: string,
+  amount: string,
+  signTransaction: any
+) {
+  const server = new rpc.Server(rpcUrl);
+  const { sequence } = await server.getLatestLedger();
+
+  const client = new Client({
+    networkPassphrase,
+    contractId: sacContractId,
+    rpcUrl,
+    publicKey: userAccount,
+  });
+  const tx = await client.approve({from: userAccount, spender: spenderAddress, amount: BigInt(amount), live_until_ledger: Number(sequence) + 100})
+  return await tx.signAndSend({signTransaction});
+}

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getAddress, isConnected, getNetwork } from "@stellar/freighter-api";
+import { getAddress, isConnected, getNetwork, signTransaction } from "@stellar/freighter-api";
 
 let account: string;
 let connected: boolean;
@@ -21,6 +21,7 @@ export function getState() {
     network,
     networkPassphrase,
     isSignedIn: isSignedIn(),
+    signTransaction
   };
 }
 
@@ -30,6 +31,7 @@ type onChangeHandler = (args: {
   network: string;
   networkPassphrase: string;
   isSignedIn: boolean;
+  signTransaction: any;
 }) => void | Promise<void>;
 
 const onChangeHandlers: onChangeHandler[] = [];
@@ -75,6 +77,7 @@ export async function refresh(forceUpdate = false) {
           network,
           networkPassphrase,
           isSignedIn: signedIn,
+          signTransaction
         }),
       ),
     );


### PR DESCRIPTION
This fixes an issue in repay debt where the signed authorization is for an amount lower than the actual transaction in the pay_interest portion of the code due to interest accruing in the intervening time. Now it only recalculates accrued interest if its been > 5 minutes since the last time it was calculated.

This PR also fixes an auth bug in transfer_from and adds several tests for the xAsset contract.