### PR TITLE
Admins can update xasset wasm in orchestrator and update child contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,7 +1826,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xasset"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "data-feed",
  "loam-sdk",

--- a/contracts/xasset-orchestrator/src/error.rs
+++ b/contracts/xasset-orchestrator/src/error.rs
@@ -18,4 +18,7 @@ pub enum Error {
 
     // "No such asset deployed"
     NoSuchAsset = 5,
+
+    // "Failed to upgrade asset contract"
+    AssetUpgradeFailed = 6,
 }

--- a/contracts/xasset-orchestrator/src/orchestrator.rs
+++ b/contracts/xasset-orchestrator/src/orchestrator.rs
@@ -13,9 +13,7 @@ use loam_subcontract_core::Core;
 pub mod xasset {
     use loam_sdk::soroban_sdk;
 
-    soroban_sdk::contractimport!(
-        file = "../../target/wasm32v1-none/release/xasset.wasm"
-    );
+    soroban_sdk::contractimport!(file = "../../target/wasm32v1-none/release/xasset.wasm");
 }
 
 #[loamstorage]
@@ -78,7 +76,7 @@ pub trait IsOrchestratorTrait {
     // Upgrade an existing asset contract to the xasset wasm of the orchestrator.
     fn upgrade_existing_asset_contract(
         &mut self,
-        asset_symbol: loam_sdk::soroban_sdk::String
+        asset_symbol: loam_sdk::soroban_sdk::String,
     ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 }
 
@@ -96,7 +94,10 @@ impl IsOrchestratorTrait for Storage {
         Ok(())
     }
 
-    fn update_xasset_wasm_hash(&mut self,xasset_wasm_hash:loam_sdk::soroban_sdk::BytesN<32> ,) -> Result<loam_sdk::soroban_sdk::BytesN<32>,Error> {
+    fn update_xasset_wasm_hash(
+        &mut self,
+        xasset_wasm_hash: loam_sdk::soroban_sdk::BytesN<32>,
+    ) -> Result<loam_sdk::soroban_sdk::BytesN<32>, Error> {
         Contract::require_auth();
         self.wasm_hash.set(&xasset_wasm_hash);
         Ok(xasset_wasm_hash)
@@ -180,10 +181,7 @@ impl IsOrchestratorTrait for Storage {
         Ok(())
     }
 
-    fn upgrade_existing_asset_contract(
-        &mut self,
-        asset_symbol: String,
-    ) -> Result<Address, Error> {
+    fn upgrade_existing_asset_contract(&mut self, asset_symbol: String) -> Result<Address, Error> {
         Contract::require_auth();
         if !self.assets.has(asset_symbol.clone()) {
             return Err(Error::NoSuchAsset);
@@ -192,7 +190,8 @@ impl IsOrchestratorTrait for Storage {
         let wasm_hash = self.wasm_hash.get().ok_or(Error::ContractNotInitalized)?;
         let env = env();
         let client = xasset::Client::new(env, &asset_contract);
-        client.try_redeploy(&wasm_hash)
+        let _ = client
+            .try_redeploy(&wasm_hash)
             .map_err(|_| Error::AssetUpgradeFailed)?;
         Ok(asset_contract)
     }

--- a/contracts/xasset-orchestrator/src/orchestrator.rs
+++ b/contracts/xasset-orchestrator/src/orchestrator.rs
@@ -43,6 +43,10 @@ pub trait IsOrchestratorTrait {
         xlm_contract: loam_sdk::soroban_sdk::Address,
         xasset_wasm_hash: loam_sdk::soroban_sdk::BytesN<32>,
     ) -> Result<(), Error>;
+    fn update_xasset_wasm_hash(
+        &mut self,
+        xasset_wasm_hash: loam_sdk::soroban_sdk::BytesN<32>,
+    ) -> Result<loam_sdk::soroban_sdk::BytesN<32>, Error>;
     #[allow(clippy::too_many_arguments)]
     fn deploy_asset_contract(
         &mut self,
@@ -71,6 +75,11 @@ pub trait IsOrchestratorTrait {
         asset_symbol: loam_sdk::soroban_sdk::String,
         asset_contract: loam_sdk::soroban_sdk::Address,
     ) -> Result<(), Error>;
+    // Upgrade an existing asset contract to the xasset wasm of the orchestrator.
+    fn upgrade_existing_asset_contract(
+        &mut self,
+        asset_symbol: loam_sdk::soroban_sdk::String
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 }
 
 impl IsOrchestratorTrait for Storage {
@@ -85,6 +94,12 @@ impl IsOrchestratorTrait for Storage {
         self.xlm_contract.set(&xlm_contract);
         self.wasm_hash.set(&xasset_wasm_hash);
         Ok(())
+    }
+
+    fn update_xasset_wasm_hash(&mut self,xasset_wasm_hash:loam_sdk::soroban_sdk::BytesN<32> ,) -> Result<loam_sdk::soroban_sdk::BytesN<32>,Error> {
+        Contract::require_auth();
+        self.wasm_hash.set(&xasset_wasm_hash);
+        Ok(xasset_wasm_hash)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -163,6 +178,23 @@ impl IsOrchestratorTrait for Storage {
         Contract::require_auth();
         self.assets.set(asset_symbol, &asset_contract);
         Ok(())
+    }
+
+    fn upgrade_existing_asset_contract(
+        &mut self,
+        asset_symbol: String,
+    ) -> Result<Address, Error> {
+        Contract::require_auth();
+        if !self.assets.has(asset_symbol.clone()) {
+            return Err(Error::NoSuchAsset);
+        }
+        let asset_contract = self.assets.get(asset_symbol.clone()).unwrap();
+        let wasm_hash = self.wasm_hash.get().ok_or(Error::ContractNotInitalized)?;
+        let env = env();
+        let client = xasset::Client::new(env, &asset_contract);
+        client.try_redeploy(&wasm_hash)
+            .map_err(|_| Error::AssetUpgradeFailed)?;
+        Ok(asset_contract)
     }
 }
 

--- a/contracts/xasset-orchestrator/src/test.rs
+++ b/contracts/xasset-orchestrator/src/test.rs
@@ -94,10 +94,4 @@ fn test_orchestrator() {
     let new_wasm_hash: BytesN<32> = e.deployer().upload_contract_wasm(xasset::WASM);
     let result = orchestrator.try_update_xasset_wasm_hash(&new_wasm_hash);
     assert_eq!(result.unwrap().unwrap(), new_wasm_hash);
-
-    // // Upgrade an existing asset contract
-    // let upgrade_result = orchestrator.try_upgrade_existing_asset_contract(&existing_symbol);
-    // assert!(upgrade_result.is_ok());
-    // let upgraded_address = upgrade_result.unwrap().unwrap();
-    // assert_eq!(upgraded_address, existing_address);
 }

--- a/contracts/xasset-orchestrator/src/test.rs
+++ b/contracts/xasset-orchestrator/src/test.rs
@@ -89,4 +89,15 @@ fn test_orchestrator() {
     let existing_updated_result = orchestrator.try_get_asset_contract(&existing_symbol);
     assert!(existing_updated_result.is_ok());
     assert_eq!(existing_updated_result.unwrap().unwrap(), existing_address);
+
+    // update the xasset wasm hash
+    let new_wasm_hash: BytesN<32> = e.deployer().upload_contract_wasm(xasset::WASM);
+    let result = orchestrator.try_update_xasset_wasm_hash(&new_wasm_hash);
+    assert_eq!(result.unwrap().unwrap(), new_wasm_hash);
+
+    // // Upgrade an existing asset contract
+    // let upgrade_result = orchestrator.try_upgrade_existing_asset_contract(&existing_symbol);
+    // assert!(upgrade_result.is_ok());
+    // let upgraded_address = upgrade_result.unwrap().unwrap();
+    // assert_eq!(upgraded_address, existing_address);
 }

--- a/contracts/xasset/Cargo.toml
+++ b/contracts/xasset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xasset"
 description = "Fungible Token that wraps another asset, creates a stability pool for it, and allows creating Collateralized Debt Positions (CDPs) against it."
-version = "0.0.0"
+version = "1.0.0"
 authors = ["Aha Labs <help@ahalabs.dev>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/contracts/xasset/src/collateralized.rs
+++ b/contracts/xasset/src/collateralized.rs
@@ -205,4 +205,9 @@ pub trait IsCDPAdmin {
 
     /// Get total interest collected
     fn get_total_interest_collected(&self) -> i128;
+
+    fn version(&self) -> u32;
+
+    /// Upgrade the xAsset contract to a new version
+    fn upgrade(&mut self, wasm_hash: loam_sdk::soroban_sdk::BytesN<32>) -> Result<(), Error>;
 }

--- a/contracts/xasset/src/collateralized.rs
+++ b/contracts/xasset/src/collateralized.rs
@@ -206,5 +206,5 @@ pub trait IsCDPAdmin {
     /// Get total interest collected
     fn get_total_interest_collected(&self) -> i128;
 
-    fn version(&self) -> u32;
+    fn version(&self) -> String;
 }

--- a/contracts/xasset/src/collateralized.rs
+++ b/contracts/xasset/src/collateralized.rs
@@ -207,7 +207,4 @@ pub trait IsCDPAdmin {
     fn get_total_interest_collected(&self) -> i128;
 
     fn version(&self) -> u32;
-
-    /// Upgrade the xAsset contract to a new version
-    fn upgrade(&mut self, wasm_hash: loam_sdk::soroban_sdk::BytesN<32>) -> Result<(), Error>;
 }

--- a/contracts/xasset/src/lib.rs
+++ b/contracts/xasset/src/lib.rs
@@ -11,10 +11,10 @@ use token::Token;
 
 pub mod collateralized;
 pub mod error;
+pub mod index_types;
 pub mod stability_pool;
 mod storage;
 pub mod token;
-pub mod index_types;
 
 use crate::storage::InterestDetail;
 pub use error::Error;
@@ -29,9 +29,7 @@ pub struct PriceData {
 pub mod data_feed {
     use loam_sdk::soroban_sdk;
 
-    soroban_sdk::contractimport!(
-        file = "../../target/wasm32v1-none/release/data_feed.wasm"
-    );
+    soroban_sdk::contractimport!(file = "../../target/wasm32v1-none/release/data_feed.wasm");
 }
 
 #[derive_contract(
@@ -40,7 +38,7 @@ pub mod data_feed {
     CDPAdmin(Token),
     Sep41(Token),
     Fungible(Token),
-    StabilityPool(Token)
+    StabilityPool(Token),
 )]
 pub struct Contract;
 

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -828,13 +828,6 @@ impl IsCDPAdmin for Token {
         self.get_total_interest_collected()
     }
 
-    fn upgrade(&mut self,wasm_hash:loam_sdk::soroban_sdk::BytesN<32>) -> Result<(),Error> {
-        self::Contract::require_auth();
-        let e = env();
-        e.deployer().update_current_contract_wasm(wasm_hash);
-        Ok(())
-    }
-
     fn version(&self) -> u32 {
         1
     }

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -2,7 +2,8 @@ use core::cmp;
 
 use loam_sdk::loamstorage;
 use loam_sdk::soroban_sdk::{
-    self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentItem, PersistentMap, String, Symbol, Vec
+    self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentItem,
+    PersistentMap, String, Symbol, Vec,
 };
 use loam_subcontract_ft::{Fungible, IsFungible, IsSep41};
 
@@ -16,7 +17,11 @@ use crate::{
     stability_pool::{AvailableAssets, IsStabilityPool, StakerPosition},
     Contract,
 };
-
+const VERSION_STRING: &str = concat!(
+    env!("CARGO_PKG_VERSION_MAJOR"), ".",
+    env!("CARGO_PKG_VERSION_MINOR"), ".",
+    env!("CARGO_PKG_VERSION_PATCH")
+);
 const BASIS_POINTS: i128 = 10_000;
 const PRODUCT_CONSTANT: i128 = 1_000_000_000;
 const DEPOSIT_FEE: i128 = 10_000_000;
@@ -469,10 +474,10 @@ impl IsCollateralized for Token {
         self.cdps.set(lender.clone(), &cdp.clone());
 
         env.events().publish(
-            (Symbol::new(&env, "CDP"), lender.clone()), 
+            (Symbol::new(&env, "CDP"), lender.clone()),
             crate::index_types::CDP {
                 id: lender.clone(),
-                xlm_deposited: cdp.xlm_deposited,  // From your existing cdp
+                xlm_deposited: cdp.xlm_deposited, // From your existing cdp
                 asset_lent: cdp.asset_lent,
                 accrued_interest: cdp.accrued_interest.amount,
                 interest_paid: cdp.accrued_interest.paid,
@@ -749,7 +754,7 @@ impl IsCollateralized for Token {
                 .map_err(|_| Error::XLMTransferFailed)?;
         }
         env().events().publish(
-        (Symbol::new(env(), "CDP"), lender.clone()),
+            (Symbol::new(env(), "CDP"), lender.clone()),
             crate::index_types::CDP {
                 id: lender.clone(),
                 xlm_deposited: cdp.xlm_deposited,
@@ -828,8 +833,8 @@ impl IsCDPAdmin for Token {
         self.get_total_interest_collected()
     }
 
-    fn version(&self) -> u32 {
-        1
+    fn version(&self) -> String {
+        String::from_str(env(), VERSION_STRING)
     }
 }
 
@@ -1146,7 +1151,7 @@ impl Token {
 
     fn set_cdp_from_decorated(&mut self, lender: Address, decorated_cdp: CDPContract) {
         env().events().publish(
-        (Symbol::new(env(), "CDP"), lender.clone()),
+            (Symbol::new(env(), "CDP"), lender.clone()),
             crate::index_types::CDP {
                 id: lender.clone(),
                 xlm_deposited: decorated_cdp.xlm_deposited,

--- a/contracts/xasset/src/token.rs
+++ b/contracts/xasset/src/token.rs
@@ -2,8 +2,7 @@ use core::cmp;
 
 use loam_sdk::loamstorage;
 use loam_sdk::soroban_sdk::{
-    self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentItem,
-    PersistentMap, String, Symbol, Vec,
+    self, env, panic_with_error, token, Address, InstanceItem, LoamKey, PersistentItem, PersistentMap, String, Symbol, Vec
 };
 use loam_subcontract_ft::{Fungible, IsFungible, IsSep41};
 
@@ -827,6 +826,17 @@ impl IsCDPAdmin for Token {
 
     fn get_total_interest_collected(&self) -> i128 {
         self.get_total_interest_collected()
+    }
+
+    fn upgrade(&mut self,wasm_hash:loam_sdk::soroban_sdk::BytesN<32>) -> Result<(),Error> {
+        self::Contract::require_auth();
+        let e = env();
+        e.deployer().update_current_contract_wasm(wasm_hash);
+        Ok(())
+    }
+
+    fn version(&self) -> u32 {
+        1
     }
 }
 


### PR DESCRIPTION
Allow the orchestrator to update its xasset wasm as well as update the child contracts.